### PR TITLE
[feat] 전역 예외를 한곳에서 처리하기 위해서 ExceptionHandler를 커스텀한다

### DIFF
--- a/src/main/java/com/kgu/studywithme/global/dto/SimpleResponseWrapper.java
+++ b/src/main/java/com/kgu/studywithme/global/dto/SimpleResponseWrapper.java
@@ -1,0 +1,10 @@
+package com.kgu.studywithme.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SimpleResponseWrapper<T> {
+    private T result;
+}

--- a/src/main/java/com/kgu/studywithme/global/exception/ApiGlobalExceptionHandler.java
+++ b/src/main/java/com/kgu/studywithme/global/exception/ApiGlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.kgu.studywithme.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ApiGlobalExceptionHandler {
+    @ExceptionHandler(StudyWithMeException.class)
+    public ResponseEntity<ErrorResponse> studyWithMeException(StudyWithMeException exception) {
+        ErrorCode code = exception.getCode();
+        return ResponseEntity
+                .status(code.getStatus())
+                .body(ErrorResponse.from(code));
+    }
+}

--- a/src/main/java/com/kgu/studywithme/global/exception/ApiGlobalExceptionHandler.java
+++ b/src/main/java/com/kgu/studywithme/global/exception/ApiGlobalExceptionHandler.java
@@ -1,8 +1,17 @@
 package com.kgu.studywithme.global.exception;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.util.List;
 
 @RestControllerAdvice
 public class ApiGlobalExceptionHandler {
@@ -12,5 +21,79 @@ public class ApiGlobalExceptionHandler {
         return ResponseEntity
                 .status(code.getStatus())
                 .body(ErrorResponse.from(code));
+    }
+
+    /**
+     * 요청 데이터 Validation 전용 ExceptionHandler (@RequestBody)
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> methodArgumentNotValidException(MethodArgumentNotValidException e) {
+        List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
+        return convert(GlobalErrorCode.VALIDATION_ERROR, extractErrorMessage(fieldErrors));
+    }
+
+    /**
+     * 요청 데이터 Validation 전용 ExceptionHandler (@ModelAttribute)
+     */
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ErrorResponse> bindException(BindException e) {
+        List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
+        return convert(GlobalErrorCode.VALIDATION_ERROR, extractErrorMessage(fieldErrors));
+    }
+
+    private String extractErrorMessage(List<FieldError> fieldErrors) {
+        if (fieldErrors.size() == 1) {
+            return fieldErrors.get(0).getDefaultMessage();
+        }
+
+        StringBuffer buffer = new StringBuffer();
+        for (FieldError error : fieldErrors) {
+            buffer.append(error.getDefaultMessage()).append("\n");
+        }
+        return buffer.toString();
+    }
+
+    /**
+     * 존재하지 않는 Endpoint 전용 ExceptionHandler
+     */
+    @ExceptionHandler({NoHandlerFoundException.class, MethodArgumentTypeMismatchException.class})
+    public ResponseEntity<ErrorResponse> noHandlerFoundException() {
+        return convert(GlobalErrorCode.NOT_SUPPORTED_URI_ERROR);
+    }
+
+    /**
+     * HTTP Request Method 오류 전용 ExceptionHandler
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> httpRequestMethodNotSupportedException() {
+        return convert(GlobalErrorCode.NOT_SUPPORTED_METHOD_ERROR);
+    }
+
+    /**
+     * MediaType 전용 ExceptionHandler
+     */
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> httpMediaTypeNotSupportedException() {
+        return convert(GlobalErrorCode.NOT_SUPPORTED_MEDIA_TYPE_ERROR);
+    }
+
+    /**
+     * 내부 서버 오류 전용 ExceptionHandler
+     */
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleAnyException() {
+        return convert(GlobalErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    private ResponseEntity<ErrorResponse> convert(ErrorCode code) {
+        return ResponseEntity
+                .status(code.getStatus())
+                .body(ErrorResponse.from(code));
+    }
+
+    private ResponseEntity<ErrorResponse> convert(ErrorCode code, String message) {
+        return ResponseEntity
+                .status(code.getStatus())
+                .body(ErrorResponse.of(code, message));
     }
 }

--- a/src/main/java/com/kgu/studywithme/global/exception/ErrorCode.java
+++ b/src/main/java/com/kgu/studywithme/global/exception/ErrorCode.java
@@ -1,0 +1,9 @@
+package com.kgu.studywithme.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getStatus();
+    String getErrorCode();
+    String getMessage();
+}

--- a/src/main/java/com/kgu/studywithme/global/exception/ErrorResponse.java
+++ b/src/main/java/com/kgu/studywithme/global/exception/ErrorResponse.java
@@ -1,0 +1,29 @@
+package com.kgu.studywithme.global.exception;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class ErrorResponse {
+    private int status;
+    private String errorCode;
+    private String message;
+
+    private ErrorResponse(ErrorCode code) {
+        this.status = code.getStatus().value();
+        this.errorCode = code.getErrorCode();
+        this.message = code.getMessage();
+    }
+
+    public static ErrorResponse from(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message) {
+        return new ErrorResponse(errorCode.getStatus().value(), errorCode.getErrorCode(), message);
+    }
+}

--- a/src/main/java/com/kgu/studywithme/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/kgu/studywithme/global/exception/GlobalErrorCode.java
@@ -1,0 +1,20 @@
+package com.kgu.studywithme.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+    NOT_SUPPORTED_URI_ERROR(HttpStatus.NOT_FOUND, "GLOBAL_001", "지원하지 않는 URL입니다."),
+    NOT_SUPPORTED_METHOD_ERROR(HttpStatus.METHOD_NOT_ALLOWED, "GLOBAL_002", "지원하지 않는 HTTP Method 요청입니다."),
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "GLOBAL_003", "잘못된 요청입니다."),
+    NOT_SUPPORTED_MEDIA_TYPE_ERROR(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "GLOBAL_004", "잘못된 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GLOBAL_005", "내부 서버 오류입니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String errorCode;
+    private final String message;
+}

--- a/src/main/java/com/kgu/studywithme/global/exception/StudyWithMeException.java
+++ b/src/main/java/com/kgu/studywithme/global/exception/StudyWithMeException.java
@@ -1,0 +1,17 @@
+package com.kgu.studywithme.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class StudyWithMeException extends RuntimeException {
+    private final ErrorCode code;
+
+    public StudyWithMeException(ErrorCode code) {
+        super(code.getMessage());
+        this.code = code;
+    }
+
+    public static StudyWithMeException type(ErrorCode code) {
+        return new StudyWithMeException(code);
+    }
+}


### PR DESCRIPTION
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [X] 🏗️ 정상적으로 프로그램이 동작하나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 예외 응답 스펙 정의 <code>ErrorCode & ErrorResponse</code>
    - 각 Domain별 예외 Enum은 <code>{도메인명}ErrorCode</code>로 구현
        - MemberErrorCode, StudyErrorCode, ...
    - 특정 Domain이 아닌 Global한 예외는 <code>GlobalErrorCode</code>에 추가
- throw된 Exception을 한곳에서 처리하기 위한 <code>ApiGlobalExceptionHandler</code>
- 추후 Controller에서 <code>String, List<...>, ...</code>등 단일 Object Value 응답 Wrapping 전용 <code>SimpleResponseWrapper</code>

Closes #5
