### PR TITLE
[feat] Member Entity 수정과 스터디 카테고리에 대한 설계를 진행한다

### DIFF
--- a/src/main/java/com/kgu/studywithme/StudyWithMeApplication.java
+++ b/src/main/java/com/kgu/studywithme/StudyWithMeApplication.java
@@ -4,8 +4,8 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class StudywithmeApplication {
+public class StudyWithMeApplication {
 	public static void main(String[] args) {
-		SpringApplication.run(StudywithmeApplication.class, args);
+		SpringApplication.run(StudyWithMeApplication.class, args);
 	}
 }

--- a/src/main/java/com/kgu/studywithme/category/domain/Category.java
+++ b/src/main/java/com/kgu/studywithme/category/domain/Category.java
@@ -1,0 +1,30 @@
+package com.kgu.studywithme.category.domain;
+
+import com.kgu.studywithme.category.exception.CategoryErrorCode;
+import com.kgu.studywithme.global.exception.StudyWithMeException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum Category {
+    LANGUAGE(1L, "어학"),
+    INTERVIEW(2L, "면접"),
+    PROGRAMMING(3L, "프로그래밍"),
+    APTITUDE_NCS(4L, "인적성 & NCS"),
+    CERTIFICATION(5L, "자격증"),
+    ETC(6L, "기타"),
+    ;
+
+    private final long id;
+    private final String name;
+
+    public static Category from(long id) {
+        return Arrays.stream(values())
+                .filter(category -> category.id == id)
+                .findFirst()
+                .orElseThrow(() -> StudyWithMeException.type(CategoryErrorCode.CATEGORY_NOT_EXIST));
+    }
+}

--- a/src/main/java/com/kgu/studywithme/category/exception/CategoryErrorCode.java
+++ b/src/main/java/com/kgu/studywithme/category/exception/CategoryErrorCode.java
@@ -1,0 +1,17 @@
+package com.kgu.studywithme.category.exception;
+
+import com.kgu.studywithme.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CategoryErrorCode implements ErrorCode {
+    CATEGORY_NOT_EXIST(HttpStatus.NOT_FOUND, "CATEGORY_001", "존재하지 않는 카테고리입니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String errorCode;
+    private final String message;
+}

--- a/src/main/java/com/kgu/studywithme/member/domain/Member.java
+++ b/src/main/java/com/kgu/studywithme/member/domain/Member.java
@@ -39,22 +39,22 @@ public class Member {
     @Column(name = "gender", nullable = false)
     private Gender gender;
 
-    @Column(name = "location", nullable = false)
-    private String location;
+    @Embedded
+    private Region region;
 
     @Builder
-    private Member(String name, Email email, Password password, LocalDate birth, String phone, Gender gender, String location) {
+    private Member(String name, Email email, Password password, LocalDate birth, String phone, Gender gender, Region region) {
         this.name = name;
         this.email = email;
         this.password = password;
         this.birth = birth;
         this.phone = phone;
         this.gender = gender;
-        this.location = location;
+        this.region = region;
     }
 
-    public static Member createMember(String name, Email email, Password password, LocalDate birth, String phone, Gender gender, String location) {
-        return new Member(name, email, password, birth, phone, gender, location);
+    public static Member createMember(String name, Email email, Password password, LocalDate birth, String phone, Gender gender, Region region) {
+        return new Member(name, email, password, birth, phone, gender, region);
     }
 
     public void changePassword(String changePassword, PasswordEncoder encoder) {
@@ -71,5 +71,13 @@ public class Member {
 
     public String getEmailValue() {
         return email.getValue();
+    }
+
+    public String getRegionProvince() {
+        return region.getProvince();
+    }
+
+    public String getRegionCity() {
+        return region.getCity();
     }
 }

--- a/src/main/java/com/kgu/studywithme/member/domain/Member.java
+++ b/src/main/java/com/kgu/studywithme/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.kgu.studywithme.member.domain;
 
+import com.kgu.studywithme.category.domain.Category;
 import com.kgu.studywithme.global.exception.StudyWithMeException;
 import com.kgu.studywithme.member.exception.MemberErrorCode;
 import lombok.AccessLevel;
@@ -10,6 +11,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -45,6 +48,16 @@ public class Member {
     @Embedded
     private Region region;
 
+    @ElementCollection
+    @CollectionTable(
+            name = "interest",
+            joinColumns = @JoinColumn(name = "member_id", referencedColumnName = "id"),
+            uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "category"})
+    )
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category")
+    private Set<Category> interests = new HashSet<>();
+
     @Builder
     private Member(String name, Nickname nickname, Email email, Password password, LocalDate birth, String phone, Gender gender, Region region) {
         this.name = name;
@@ -59,6 +72,10 @@ public class Member {
 
     public static Member createMember(String name, Nickname nickname, Email email, Password password, LocalDate birth, String phone, Gender gender, Region region) {
         return new Member(name, nickname, email, password, birth, phone, gender, region);
+    }
+
+    public void addCategoriesToInterests(Set<Category> categories) {
+        interests.addAll(categories);
     }
 
     public void changeNickname(String changeNickname) {

--- a/src/main/java/com/kgu/studywithme/member/domain/Member.java
+++ b/src/main/java/com/kgu/studywithme/member/domain/Member.java
@@ -24,6 +24,9 @@ public class Member {
     private String name;
 
     @Embedded
+    private Nickname nickname;
+
+    @Embedded
     private Email email;
 
     @Embedded
@@ -43,8 +46,9 @@ public class Member {
     private Region region;
 
     @Builder
-    private Member(String name, Email email, Password password, LocalDate birth, String phone, Gender gender, Region region) {
+    private Member(String name, Nickname nickname, Email email, Password password, LocalDate birth, String phone, Gender gender, Region region) {
         this.name = name;
+        this.nickname = nickname;
         this.email = email;
         this.password = password;
         this.birth = birth;
@@ -53,8 +57,15 @@ public class Member {
         this.region = region;
     }
 
-    public static Member createMember(String name, Email email, Password password, LocalDate birth, String phone, Gender gender, Region region) {
-        return new Member(name, email, password, birth, phone, gender, region);
+    public static Member createMember(String name, Nickname nickname, Email email, Password password, LocalDate birth, String phone, Gender gender, Region region) {
+        return new Member(name, nickname, email, password, birth, phone, gender, region);
+    }
+
+    public void changeNickname(String changeNickname) {
+        if (this.nickname.isSameNickname(changeNickname)) {
+            throw StudyWithMeException.type(MemberErrorCode.NICKNAME_SAME_AS_BEFORE);
+        }
+        this.nickname = this.nickname.update(changeNickname);
     }
 
     public void changePassword(String changePassword, PasswordEncoder encoder) {
@@ -65,6 +76,10 @@ public class Member {
     }
 
     // Add Getter
+    public String getNicknameValue() {
+        return nickname.getValue();
+    }
+
     public String getPasswordValue() {
         return password.getValue();
     }

--- a/src/main/java/com/kgu/studywithme/member/domain/Nickname.java
+++ b/src/main/java/com/kgu/studywithme/member/domain/Nickname.java
@@ -1,0 +1,53 @@
+package com.kgu.studywithme.member.domain;
+
+import com.kgu.studywithme.global.exception.StudyWithMeException;
+import com.kgu.studywithme.member.exception.MemberErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.util.regex.Pattern;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class Nickname {
+    // 한글 & 알파벳 대소문자 & 숫자 가능
+    // 공백 불가능
+    // 2자 이상 10자 이하
+    private static final String NICKNAME_PATTERN = "^[a-zA-Z가-힣0-9]{2,10}$";
+    private static final Pattern NICKNAME_MATCHER = Pattern.compile(NICKNAME_PATTERN);
+
+    @Column(name = "nickname", nullable = false, unique = true)
+    private String value;
+
+    private Nickname(String value) {
+        this.value = value;
+    }
+
+    public static Nickname from(String value) {
+        validateNicknamePattern(value);
+        return new Nickname(value);
+    }
+
+    public Nickname update(String value) {
+        validateNicknamePattern(value);
+        return new Nickname(value);
+    }
+
+    private static void validateNicknamePattern(String value) {
+        if (isNotValidPattern(value)) {
+            throw StudyWithMeException.type(MemberErrorCode.INVALID_NICKNAME_PATTERN);
+        }
+    }
+
+    private static boolean isNotValidPattern(String nickname) {
+        return !NICKNAME_MATCHER.matcher(nickname).matches();
+    }
+
+    public boolean isSameNickname(String compareNickname) {
+        return this.value.equals(compareNickname);
+    }
+}

--- a/src/main/java/com/kgu/studywithme/member/domain/Region.java
+++ b/src/main/java/com/kgu/studywithme/member/domain/Region.java
@@ -1,0 +1,42 @@
+package com.kgu.studywithme.member.domain;
+
+import com.kgu.studywithme.global.exception.StudyWithMeException;
+import com.kgu.studywithme.member.exception.MemberErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class Region {
+    @Column(name = "province", nullable = false)
+    private String province;
+
+    @Column(name = "city", nullable = false)
+    private String city;
+
+    private Region(String province, String city) {
+        this.province = province;
+        this.city = city;
+    }
+
+    public static Region of(String province, String city) {
+        validateInputRegion(province, city);
+        return new Region(province, city);
+    }
+
+    private static void validateInputRegion(String province, String city) {
+        if (isEmptyText(province) || isEmptyText(city)) {
+            throw StudyWithMeException.type(MemberErrorCode.INVALID_REGION);
+        }
+    }
+
+    private static boolean isEmptyText(String str) {
+        return !StringUtils.hasText(str);
+    }
+}

--- a/src/main/java/com/kgu/studywithme/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/kgu/studywithme/member/exception/MemberErrorCode.java
@@ -12,6 +12,8 @@ public enum MemberErrorCode implements ErrorCode {
     INVALID_PASSWORD_PATTERN(HttpStatus.BAD_REQUEST, "MEMBER_002", "비밀번호는 영문/숫자/특수문자를 각각 하나 이상 포함해야 하고 8자 이상 25자 이하여야 합니다."),
     PASSWORD_SAME_AS_BEFORE(HttpStatus.CONFLICT, "MEMBER_003", "이전과 동일한 비밀번호로 변경할 수 없습니다."),
     INVALID_REGION(HttpStatus.BAD_REQUEST, "MEMBER_004", "거주지를 정확하게 입력해주세요."),
+    INVALID_NICKNAME_PATTERN(HttpStatus.BAD_REQUEST, "MEMBER_005", "닉네임 형식에 맞지 않습니다."),
+    NICKNAME_SAME_AS_BEFORE(HttpStatus.BAD_REQUEST, "MEMBER_006", "이전과 동일한 닉네임으로 변경할 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/kgu/studywithme/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/kgu/studywithme/member/exception/MemberErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum MemberErrorCode implements ErrorCode {
     INVALID_EMAIL_PATTERN(HttpStatus.BAD_REQUEST, "MEMBER_001", "이메일 형식에 맞지 않습니다."),
     INVALID_PASSWORD_PATTERN(HttpStatus.BAD_REQUEST, "MEMBER_002", "비밀번호는 영문/숫자/특수문자를 각각 하나 이상 포함해야 하고 8자 이상 25자 이하여야 합니다."),
-    PASSWORD_SAME_AS_BEFORE(HttpStatus.CONFLICT, "MEMBER_003", "이전과 동일한 비밀번호로 변경할 수 없습니다.")
+    PASSWORD_SAME_AS_BEFORE(HttpStatus.CONFLICT, "MEMBER_003", "이전과 동일한 비밀번호로 변경할 수 없습니다."),
+    INVALID_REGION(HttpStatus.BAD_REQUEST, "MEMBER_004", "거주지를 정확하게 입력해주세요."),
     ;
 
     private final HttpStatus status;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,7 +3,7 @@ spring:
     activate:
       on-profile: dev
     import:
-      - security/application.yml
+      - security/application-external.yml
       - security/application-dev-datasource.yml
       - application-logging.yml
       - application-mapping.yml

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,7 +3,7 @@ spring:
     activate:
       on-profile: prod
     import:
-      - security/application.yml
+      - security/application-external.yml
       - security/application-prod-datasource.yml
       - application-logging.yml
       - application-mapping.yml

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,7 +1,7 @@
 spring:
   config:
     import:
-      - security/application.yml
+      - security/application-external.yml
       - application-test-datasource.yml
       - application-logging.yml
       - application-mapping.yml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,7 @@
 spring:
   config:
-    activate:
-      on-profile: local
     import:
-      - security/application.yml
+      - security/application-external.yml
       - security/application-local-datasource.yml
       - application-logging.yml
       - application-mapping.yml

--- a/src/test/java/com/kgu/studywithme/category/domain/CategoryTest.java
+++ b/src/test/java/com/kgu/studywithme/category/domain/CategoryTest.java
@@ -1,0 +1,33 @@
+package com.kgu.studywithme.category.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.kgu.studywithme.category.domain.Category.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("Category 도메인 테스트")
+class CategoryTest {
+    @Test
+    @DisplayName("특정 카테고리를 조회한다")
+    void test() {
+        // given
+        final long language = 1L;
+        final long interview = 2L;
+        final long programming = 3L;
+        final long aptituteAndNcs = 4L;
+        final long certification = 5L;
+        final long etc = 6L;
+
+        // when - then
+        assertAll(
+                () -> assertThat(Category.from(language)).isEqualTo(LANGUAGE),
+                () -> assertThat(Category.from(interview)).isEqualTo(INTERVIEW),
+                () -> assertThat(Category.from(programming)).isEqualTo(PROGRAMMING),
+                () -> assertThat(Category.from(aptituteAndNcs)).isEqualTo(APTITUDE_NCS),
+                () -> assertThat(Category.from(certification)).isEqualTo(CERTIFICATION),
+                () -> assertThat(Category.from(etc)).isEqualTo(ETC)
+        );
+    }
+}

--- a/src/test/java/com/kgu/studywithme/fixture/MemberFixture.java
+++ b/src/test/java/com/kgu/studywithme/fixture/MemberFixture.java
@@ -11,10 +11,11 @@ import static com.kgu.studywithme.common.utils.PasswordEncoderUtils.ENCODER;
 @Getter
 @RequiredArgsConstructor
 public enum MemberFixture {
-    SEO_JI_WON("서지원", "sjiwon4491@gmail.com", "abcABC123!@#", LocalDate.of(2000, 1, 18), Gender.MALE, "경기도", "안양시"),
+    SEO_JI_WON("서지원", "서지원", "sjiwon4491@gmail.com", "abcABC123!@#", LocalDate.of(2000, 1, 18), Gender.MALE, "경기도", "안양시"),
     ;
 
     private final String name;
+    private final String nickname;
     private final String email;
     private final String password;
     private final LocalDate birth;
@@ -25,6 +26,7 @@ public enum MemberFixture {
     public Member toMember() {
         return Member.builder()
                 .name(name)
+                .nickname(Nickname.from(nickname))
                 .email(Email.from(email))
                 .password(Password.encrypt(password, ENCODER))
                 .birth(birth)

--- a/src/test/java/com/kgu/studywithme/fixture/MemberFixture.java
+++ b/src/test/java/com/kgu/studywithme/fixture/MemberFixture.java
@@ -1,9 +1,6 @@
 package com.kgu.studywithme.fixture;
 
-import com.kgu.studywithme.member.domain.Email;
-import com.kgu.studywithme.member.domain.Gender;
-import com.kgu.studywithme.member.domain.Member;
-import com.kgu.studywithme.member.domain.Password;
+import com.kgu.studywithme.member.domain.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -14,7 +11,7 @@ import static com.kgu.studywithme.common.utils.PasswordEncoderUtils.ENCODER;
 @Getter
 @RequiredArgsConstructor
 public enum MemberFixture {
-    SEO_JI_WON("서지원", "sjiwon4491@gmail.com", "abcABC123!@#", LocalDate.of(2000, 1, 18), Gender.MALE, "안양"),
+    SEO_JI_WON("서지원", "sjiwon4491@gmail.com", "abcABC123!@#", LocalDate.of(2000, 1, 18), Gender.MALE, "경기도", "안양시"),
     ;
 
     private final String name;
@@ -22,7 +19,8 @@ public enum MemberFixture {
     private final String password;
     private final LocalDate birth;
     private final Gender gender;
-    private final String location;
+    private final String province;
+    private final String city;
 
     public Member toMember() {
         return Member.builder()
@@ -32,7 +30,7 @@ public enum MemberFixture {
                 .birth(birth)
                 .phone(generateRandomPhoneNumber())
                 .gender(gender)
-                .location(location)
+                .region(Region.of(province, city))
                 .build();
     }
 

--- a/src/test/java/com/kgu/studywithme/member/domain/MemberTest.java
+++ b/src/test/java/com/kgu/studywithme/member/domain/MemberTest.java
@@ -1,10 +1,15 @@
 package com.kgu.studywithme.member.domain;
 
+import com.kgu.studywithme.category.domain.Category;
 import com.kgu.studywithme.global.exception.StudyWithMeException;
 import com.kgu.studywithme.member.exception.MemberErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+
+import static com.kgu.studywithme.category.domain.Category.INTERVIEW;
+import static com.kgu.studywithme.category.domain.Category.PROGRAMMING;
 import static com.kgu.studywithme.common.utils.PasswordEncoderUtils.ENCODER;
 import static com.kgu.studywithme.fixture.MemberFixture.SEO_JI_WON;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,6 +32,30 @@ class MemberTest {
                 () -> assertThat(member.getGender()).isEqualTo(SEO_JI_WON.getGender()),
                 () -> assertThat(member.getRegionProvince()).isEqualTo(SEO_JI_WON.getProvince()),
                 () -> assertThat(member.getRegionCity()).isEqualTo(SEO_JI_WON.getCity())
+        );
+    }
+
+    @Test
+    @DisplayName("관심사와 함께 멤버를 생성한다")
+    void createMemberWithInterests() {
+        // given
+        final Set<Category> interests = Set.of(PROGRAMMING, INTERVIEW);
+
+        // when
+        Member member = SEO_JI_WON.toMember();
+        member.addCategoriesToInterests(interests);
+
+        // then
+        assertAll(
+                () -> assertThat(member.getName()).isEqualTo(SEO_JI_WON.getName()),
+                () -> assertThat(member.getNicknameValue()).isEqualTo(SEO_JI_WON.getNickname()),
+                () -> assertThat(member.getEmailValue()).isEqualTo(SEO_JI_WON.getEmail()),
+                () -> assertThat(ENCODER.matches(SEO_JI_WON.getPassword(), member.getPasswordValue())).isTrue(),
+                () -> assertThat(member.getBirth()).isEqualTo(SEO_JI_WON.getBirth()),
+                () -> assertThat(member.getGender()).isEqualTo(SEO_JI_WON.getGender()),
+                () -> assertThat(member.getRegionProvince()).isEqualTo(SEO_JI_WON.getProvince()),
+                () -> assertThat(member.getRegionCity()).isEqualTo(SEO_JI_WON.getCity()),
+                () -> assertThat(member.getInterests()).containsAll(interests)
         );
     }
 

--- a/src/test/java/com/kgu/studywithme/member/domain/MemberTest.java
+++ b/src/test/java/com/kgu/studywithme/member/domain/MemberTest.java
@@ -20,6 +20,7 @@ class MemberTest {
 
         assertAll(
                 () -> assertThat(member.getName()).isEqualTo(SEO_JI_WON.getName()),
+                () -> assertThat(member.getNicknameValue()).isEqualTo(SEO_JI_WON.getNickname()),
                 () -> assertThat(member.getEmailValue()).isEqualTo(SEO_JI_WON.getEmail()),
                 () -> assertThat(ENCODER.matches(SEO_JI_WON.getPassword(), member.getPasswordValue())).isTrue(),
                 () -> assertThat(member.getBirth()).isEqualTo(SEO_JI_WON.getBirth()),
@@ -46,5 +47,24 @@ class MemberTest {
 
         // then
         assertThat(ENCODER.matches(diff, member.getPasswordValue())).isTrue();
+    }
+
+    @Test
+    @DisplayName("닉네임을 변경한다")
+    void changeNickname() {
+        // given
+        Member member = SEO_JI_WON.toMember();
+        final String same = SEO_JI_WON.getNickname();
+        final String diff = SEO_JI_WON.getNickname() + "diff";
+
+        // when
+        assertThatThrownBy(() -> member.changeNickname(same))
+                .isInstanceOf(StudyWithMeException.class)
+                .hasMessage(MemberErrorCode.NICKNAME_SAME_AS_BEFORE.getMessage());
+
+        member.changeNickname(diff);
+
+        // then
+        assertThat(member.getNicknameValue()).isEqualTo(diff);
     }
 }

--- a/src/test/java/com/kgu/studywithme/member/domain/MemberTest.java
+++ b/src/test/java/com/kgu/studywithme/member/domain/MemberTest.java
@@ -24,7 +24,8 @@ class MemberTest {
                 () -> assertThat(ENCODER.matches(SEO_JI_WON.getPassword(), member.getPasswordValue())).isTrue(),
                 () -> assertThat(member.getBirth()).isEqualTo(SEO_JI_WON.getBirth()),
                 () -> assertThat(member.getGender()).isEqualTo(SEO_JI_WON.getGender()),
-                () -> assertThat(member.getLocation()).isEqualTo(SEO_JI_WON.getLocation())
+                () -> assertThat(member.getRegionProvince()).isEqualTo(SEO_JI_WON.getProvince()),
+                () -> assertThat(member.getRegionCity()).isEqualTo(SEO_JI_WON.getCity())
         );
     }
 

--- a/src/test/java/com/kgu/studywithme/member/domain/NicknameTest.java
+++ b/src/test/java/com/kgu/studywithme/member/domain/NicknameTest.java
@@ -1,0 +1,60 @@
+package com.kgu.studywithme.member.domain;
+
+import com.kgu.studywithme.global.exception.StudyWithMeException;
+import com.kgu.studywithme.member.exception.MemberErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("Member 도메인 {Nickname VO} 테스트")
+class NicknameTest {
+    @ParameterizedTest(name = "{index}: {0}")
+    @ValueSource(strings = {"한", "!@#hello", "Hello World", "일이삼사오육칠팔구십십일"})
+    @DisplayName("형식에 맞지 않는 닉네임은 예외가 발생한다")
+    void throwExceptionByMalformedNickname(String value){
+        assertThatThrownBy(() -> Nickname.from(value))
+                .isInstanceOf(StudyWithMeException.class)
+                .hasMessage(MemberErrorCode.INVALID_NICKNAME_PATTERN.getMessage());
+    }
+
+    @ParameterizedTest(name = "{index}: {0}")
+    @ValueSource(strings = {"HelloWorld", "HelloJava"})
+    @DisplayName("닉네임 업데이트에 성공한다")
+    void updateNickname(String value){
+        // given
+        Nickname nickname = Nickname.from("Hello");
+
+        // when
+        Nickname updateNickname = nickname.update(value);
+
+        // then
+        assertAll(
+                () -> assertThat(updateNickname.getValue()).isNotEqualTo(nickname.getValue()),
+                () -> assertThat(updateNickname.getValue()).isEqualTo(value)
+        );
+    }
+
+    @Test
+    @DisplayName("이전과 동일한 닉네임인지 검증한다")
+    void validateNicknameSameAsBefore() {
+        // given
+        Nickname nickname = Nickname.from("HelloWorld");
+        String compareNickname1 = "HelloWorld";
+        String compareNickname2 = "HelloJava";
+
+        // when
+        boolean actual1 = nickname.isSameNickname(compareNickname1);
+        boolean actual2 = nickname.isSameNickname(compareNickname2);
+
+        // then
+        assertAll(
+                () -> assertThat(actual1).isTrue(),
+                () -> assertThat(actual2).isFalse()
+        );
+    }
+}


### PR DESCRIPTION
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [X] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 정상적으로 프로그램이 동작하나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 로컬 환경에서의 yml 설정 변경
    - 로컬에서는 실행시 profile을 적용할 필요없이 default profile을 활용
- 사용자 거주지 설계 수정
    - location -> <code>Region[province / city]</code>
- 사용자 닉네임에 대한 <code>Nickname VO</code> 추가
- 스터디 카테고리 Enum 구현
- 사용자의 카테고리 관심사에 대한 <code>@ElementCollection</code> 구현
    - 사용자의 관심사는 스터디 카테고리 목록에서만 선택 가능

Closes #16
