### PR TITLE
[feat] 서비스 자체 로그인 & 로그아웃 로직을 구현한다

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -1,4 +1,4 @@
-= 로그인 API
+= 로그인 & 로그아웃 API
 :doctype: book
 :icons: font
 :source-highlighter: highlightjs
@@ -30,3 +30,19 @@ include::{snippets}/AuthApi/Login/Success/request-fields.adoc[]
 HTTP Response
 include::{snippets}/AuthApi/Login/Success/response-body.adoc[]
 include::{snippets}/AuthApi/Login/Success/response-fields.adoc[]
+
+== 로그아웃
+=== 1. Authorization Header에 AccessToken이 없으면 로그아웃에 실패한다
+HTTP Request
+include::{snippets}/AuthApi/Logout/Failure/http-request.adoc[]
+
+HTTP Response
+include::{snippets}/AuthApi/Logout/Failure/response-body.adoc[]
+
+=== 2. 로그아웃에 성공한다
+HTTP Request
+include::{snippets}/AuthApi/Logout/Success/http-request.adoc[]
+include::{snippets}/AuthApi/Logout/Success/request-headers.adoc[]
+
+HTTP Response
+include::{snippets}/AuthApi/Logout/Success/http-response.adoc[]

--- a/src/docs/asciidoc/login.adoc
+++ b/src/docs/asciidoc/login.adoc
@@ -1,0 +1,32 @@
+= 로그인 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+== 로그인
+=== 1. 이메일에 해당하는 사용자가 없으면 로그인에 실패한다
+HTTP Request
+include::{snippets}/AuthApi/Login/Failure/Case1/http-request.adoc[]
+include::{snippets}/AuthApi/Login/Failure/Case1/request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/AuthApi/Login/Failure/Case1/response-body.adoc[]
+
+=== 2. 비밀번호가 일치하지 않으면 로그인에 실패한다
+HTTP Request
+include::{snippets}/AuthApi/Login/Failure/Case2/http-request.adoc[]
+include::{snippets}/AuthApi/Login/Failure/Case2/request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/AuthApi/Login/Failure/Case2/response-body.adoc[]
+
+=== 3. 정보가 모두 일치하면 로그인에 성공하고 Access Token & Refresh Token을 발급받는다
+HTTP Request
+include::{snippets}/AuthApi/Login/Success/http-request.adoc[]
+include::{snippets}/AuthApi/Login/Success/request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/AuthApi/Login/Success/response-body.adoc[]
+include::{snippets}/AuthApi/Login/Success/response-fields.adoc[]

--- a/src/main/java/com/kgu/studywithme/auth/controller/AuthApiController.java
+++ b/src/main/java/com/kgu/studywithme/auth/controller/AuthApiController.java
@@ -3,6 +3,7 @@ package com.kgu.studywithme.auth.controller;
 import com.kgu.studywithme.auth.controller.dto.request.LoginRequest;
 import com.kgu.studywithme.auth.service.AuthService;
 import com.kgu.studywithme.auth.service.dto.response.TokenResponse;
+import com.kgu.studywithme.global.annotation.ExtractPayload;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,5 +23,11 @@ public class AuthApiController {
     public ResponseEntity<TokenResponse> login(@RequestBody @Valid LoginRequest request) {
         TokenResponse tokenResponse = authService.login(request.email(), request.password());
         return ResponseEntity.ok(tokenResponse);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@ExtractPayload Long memberId) {
+        authService.logout(memberId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/kgu/studywithme/auth/controller/AuthApiController.java
+++ b/src/main/java/com/kgu/studywithme/auth/controller/AuthApiController.java
@@ -1,0 +1,26 @@
+package com.kgu.studywithme.auth.controller;
+
+import com.kgu.studywithme.auth.controller.dto.request.LoginRequest;
+import com.kgu.studywithme.auth.service.AuthService;
+import com.kgu.studywithme.auth.service.dto.response.TokenResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AuthApiController {
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(@RequestBody @Valid LoginRequest request) {
+        TokenResponse tokenResponse = authService.login(request.email(), request.password());
+        return ResponseEntity.ok(tokenResponse);
+    }
+}

--- a/src/main/java/com/kgu/studywithme/auth/controller/dto/request/LoginRequest.java
+++ b/src/main/java/com/kgu/studywithme/auth/controller/dto/request/LoginRequest.java
@@ -1,0 +1,17 @@
+package com.kgu.studywithme.auth.controller.dto.request;
+
+import com.kgu.studywithme.auth.exception.AuthRequestValidationMessage;
+import lombok.Builder;
+
+import javax.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = AuthRequestValidationMessage.Login.EMAIL)
+        String email,
+
+        @NotBlank(message = AuthRequestValidationMessage.Login.PASSWORD)
+        String password
+) {
+    @Builder
+    public LoginRequest {}
+}

--- a/src/main/java/com/kgu/studywithme/auth/exception/AuthRequestValidationMessage.java
+++ b/src/main/java/com/kgu/studywithme/auth/exception/AuthRequestValidationMessage.java
@@ -1,0 +1,8 @@
+package com.kgu.studywithme.auth.exception;
+
+public class AuthRequestValidationMessage {
+    public static class Login {
+        public static final String EMAIL = "이메일은 필수입니다.";
+        public static final String PASSWORD = "비밀번호는 필수입니다.";
+    }
+}

--- a/src/main/java/com/kgu/studywithme/auth/service/AuthService.java
+++ b/src/main/java/com/kgu/studywithme/auth/service/AuthService.java
@@ -47,4 +47,9 @@ public class AuthService {
                 .refreshToken(refreshToken)
                 .build();
     }
+
+    @Transactional
+    public void logout(Long memberId) {
+        tokenManager.deleteRefreshTokenByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/kgu/studywithme/auth/service/AuthService.java
+++ b/src/main/java/com/kgu/studywithme/auth/service/AuthService.java
@@ -1,0 +1,50 @@
+package com.kgu.studywithme.auth.service;
+
+import com.kgu.studywithme.auth.service.dto.response.TokenResponse;
+import com.kgu.studywithme.auth.utils.JwtTokenProvider;
+import com.kgu.studywithme.global.exception.StudyWithMeException;
+import com.kgu.studywithme.member.domain.Member;
+import com.kgu.studywithme.member.exception.MemberErrorCode;
+import com.kgu.studywithme.member.service.MemberFindService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.kgu.studywithme.global.utils.PasswordEncoderUtils.ENCODER;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthService {
+    private final MemberFindService memberFindService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenManager tokenManager;
+
+    @Transactional
+    public TokenResponse login(String email, String password) {
+        Member member = memberFindService.findByEmail(email);
+        validatePassword(member.getPasswordValue(), password);
+        return issueTokens(member.getId());
+    }
+
+    private void validatePassword(String encodedPassword, String comparePassword) {
+        if (isNotCorrectPassword(encodedPassword, comparePassword)) {
+            throw StudyWithMeException.type(MemberErrorCode.WRONG_PASSWORD);
+        }
+    }
+
+    private boolean isNotCorrectPassword(String encodedPassword, String comparePassword) {
+        return !ENCODER.matches(comparePassword, encodedPassword);
+    }
+
+    private TokenResponse issueTokens(Long memberId) {
+        String accessToken = jwtTokenProvider.createAccessToken(memberId);
+        String refreshToken = jwtTokenProvider.createRefreshToken(memberId);
+        tokenManager.synchronizeRefreshToken(memberId, refreshToken);
+
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/kgu/studywithme/member/domain/MemberRepository.java
+++ b/src/main/java/com/kgu/studywithme/member/domain/MemberRepository.java
@@ -2,7 +2,10 @@ package com.kgu.studywithme.member.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(Email email);
     boolean existsByEmail(Email email);
     boolean existsByNickname(Nickname nickname);
     boolean existsByPhone(String phone);

--- a/src/main/java/com/kgu/studywithme/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/kgu/studywithme/member/exception/MemberErrorCode.java
@@ -18,6 +18,7 @@ public enum MemberErrorCode implements ErrorCode {
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "MEMBER_008", "이미 사용중인 닉네임입니다."),
     DUPLICATE_PHONE(HttpStatus.CONFLICT, "MEMBER_009", "이미 사용중인 전화번호입니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_010", "사용자 정보를 찾을 수 없습니다."),
+    WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "MEMBER_011", "비밀번호가 일치하지 않습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/kgu/studywithme/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/kgu/studywithme/member/exception/MemberErrorCode.java
@@ -16,7 +16,8 @@ public enum MemberErrorCode implements ErrorCode {
     NICKNAME_SAME_AS_BEFORE(HttpStatus.BAD_REQUEST, "MEMBER_006", "이전과 동일한 닉네임으로 변경할 수 없습니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "MEMBER_007", "이미 사용중인 이메일입니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "MEMBER_008", "이미 사용중인 닉네임입니다."),
-    DUPLICATE_PHONE(HttpStatus.CONFLICT, "MEMBER_009", "이미 사용중인 전화번호입니다"),
+    DUPLICATE_PHONE(HttpStatus.CONFLICT, "MEMBER_009", "이미 사용중인 전화번호입니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_010", "사용자 정보를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/kgu/studywithme/member/service/MemberFindService.java
+++ b/src/main/java/com/kgu/studywithme/member/service/MemberFindService.java
@@ -1,0 +1,22 @@
+package com.kgu.studywithme.member.service;
+
+import com.kgu.studywithme.global.exception.StudyWithMeException;
+import com.kgu.studywithme.member.domain.Email;
+import com.kgu.studywithme.member.domain.Member;
+import com.kgu.studywithme.member.domain.MemberRepository;
+import com.kgu.studywithme.member.exception.MemberErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberFindService {
+    private final MemberRepository memberRepository;
+
+    public Member findByEmail(String email) {
+        return memberRepository.findByEmail(Email.from(email))
+                .orElseThrow(() -> StudyWithMeException.type(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/test/java/com/kgu/studywithme/auth/controller/AuthApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/auth/controller/AuthApiControllerTest.java
@@ -1,0 +1,156 @@
+package com.kgu.studywithme.auth.controller;
+
+import com.kgu.studywithme.auth.controller.dto.request.LoginRequest;
+import com.kgu.studywithme.auth.controller.utils.LoginRequestUtils;
+import com.kgu.studywithme.auth.service.dto.response.TokenResponse;
+import com.kgu.studywithme.common.ControllerTest;
+import com.kgu.studywithme.global.exception.StudyWithMeException;
+import com.kgu.studywithme.member.exception.MemberErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static com.kgu.studywithme.common.utils.TokenUtils.ACCESS_TOKEN;
+import static com.kgu.studywithme.common.utils.TokenUtils.REFRESH_TOKEN;
+import static com.kgu.studywithme.fixture.MemberFixture.SEO_JI_WON;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Auth [Controller Layer] -> AuthApiController 테스트")
+class AuthApiControllerTest extends ControllerTest {
+    @Nested
+    @DisplayName("로그인 API 테스트 [POST /api/login]")
+    class login {
+        private static final String BASE_URL = "/api/login";
+
+        @Test
+        @DisplayName("이메일에 해당하는 사용자가 없으면 로그인에 실패한다")
+        void wrongEmail() throws Exception {
+            // given
+            final LoginRequest request = LoginRequestUtils.createRequest("diff" + SEO_JI_WON.getEmail(), SEO_JI_WON.getPassword());
+            given(authService.login(anyString(), anyString())).willThrow(StudyWithMeException.type(MemberErrorCode.MEMBER_NOT_FOUND));
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                    .post(BASE_URL)
+                    .contentType(APPLICATION_JSON)
+                    .content(convertObjectToJson(request));
+
+            // then
+            final MemberErrorCode expectedError = MemberErrorCode.MEMBER_NOT_FOUND;
+            mockMvc.perform(requestBuilder)
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").exists())
+                    .andExpect(jsonPath("$.status").value(expectedError.getStatus().value()))
+                    .andExpect(jsonPath("$.errorCode").exists())
+                    .andExpect(jsonPath("$.errorCode").value(expectedError.getErrorCode()))
+                    .andExpect(jsonPath("$.message").exists())
+                    .andExpect(jsonPath("$.message").value(expectedError.getMessage()))
+                    .andDo(
+                            document(
+                                    "AuthApi/Login/Failure/Case1",
+                                    applyRequestPreprocessor(),
+                                    applyResponsePreprocessor(),
+                                    requestFields(
+                                            fieldWithPath("email").description("로그인 이메일"),
+                                            fieldWithPath("password").description("로그인 비밀번호")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("비밀번호가 일치하지 않으면 로그인에 실패한다")
+        void wrongPassword() throws Exception {
+            // given
+            final LoginRequest request = LoginRequestUtils.createRequest(SEO_JI_WON.getEmail(), "diff" + SEO_JI_WON.getPassword());
+            given(authService.login(anyString(), anyString())).willThrow(StudyWithMeException.type(MemberErrorCode.WRONG_PASSWORD));
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                    .post(BASE_URL)
+                    .contentType(APPLICATION_JSON)
+                    .content(convertObjectToJson(request));
+
+            // then
+            final MemberErrorCode expectedError = MemberErrorCode.WRONG_PASSWORD;
+            mockMvc.perform(requestBuilder)
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").exists())
+                    .andExpect(jsonPath("$.status").value(expectedError.getStatus().value()))
+                    .andExpect(jsonPath("$.errorCode").exists())
+                    .andExpect(jsonPath("$.errorCode").value(expectedError.getErrorCode()))
+                    .andExpect(jsonPath("$.message").exists())
+                    .andExpect(jsonPath("$.message").value(expectedError.getMessage()))
+                    .andDo(
+                            document(
+                                    "AuthApi/Login/Failure/Case2",
+                                    applyRequestPreprocessor(),
+                                    applyResponsePreprocessor(),
+                                    requestFields(
+                                            fieldWithPath("email").description("로그인 이메일"),
+                                            fieldWithPath("password").description("로그인 비밀번호")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("정보가 모두 일치하면 로그인에 성공하고 Access Token & Refresh Token을 발급받는다")
+        void success() throws Exception {
+            // given
+            final LoginRequest request = LoginRequestUtils.createRequest(SEO_JI_WON.getEmail(), SEO_JI_WON.getPassword());
+            final TokenResponse response = TokenResponse.builder()
+                    .accessToken(ACCESS_TOKEN)
+                    .refreshToken(REFRESH_TOKEN)
+                    .build();
+            given(authService.login(anyString(), anyString())).willReturn(response);
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                    .post(BASE_URL)
+                    .contentType(APPLICATION_JSON)
+                    .content(convertObjectToJson(request));
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.accessToken").exists())
+                    .andExpect(jsonPath("$.accessToken").value(ACCESS_TOKEN))
+                    .andExpect(jsonPath("$.refreshToken").exists())
+                    .andExpect(jsonPath("$.refreshToken").value(REFRESH_TOKEN))
+                    .andDo(
+                            document(
+                                    "AuthApi/Login/Success",
+                                    applyRequestPreprocessor(),
+                                    applyResponsePreprocessor(),
+                                    requestFields(
+                                            fieldWithPath("email").description("로그인 이메일"),
+                                            fieldWithPath("password").description("로그인 비밀번호")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("accessToken").description("발급된 Access Token (Expire - 2시간)"),
+                                            fieldWithPath("refreshToken").description("발급된 Refresh Token (Expire - 2주)")
+                                    )
+                            )
+                    );
+        }
+    }
+}

--- a/src/test/java/com/kgu/studywithme/auth/controller/utils/LoginRequestUtils.java
+++ b/src/test/java/com/kgu/studywithme/auth/controller/utils/LoginRequestUtils.java
@@ -1,0 +1,12 @@
+package com.kgu.studywithme.auth.controller.utils;
+
+import com.kgu.studywithme.auth.controller.dto.request.LoginRequest;
+
+public class LoginRequestUtils {
+    public static LoginRequest createRequest(String email, String password) {
+        return LoginRequest.builder()
+                .email(email)
+                .password(password)
+                .build();
+    }
+}

--- a/src/test/java/com/kgu/studywithme/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/kgu/studywithme/auth/service/AuthServiceTest.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.Optional;
+
 import static com.kgu.studywithme.fixture.MemberFixture.SEO_JI_WON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -87,5 +89,19 @@ class AuthServiceTest extends ServiceTest {
                     }
             );
         }
+    }
+
+    @Test
+    @DisplayName("로그아웃을 진행하면 사용자에게 발급되었던 RefreshToken이 DB에서 삭제된다")
+    void logout() {
+        // given
+        final Long memberId = member.getId();
+
+        // when
+        authService.logout(memberId);
+
+        // then
+        Optional<Token> findToken = tokenRepository.findByMemberId(memberId);
+        assertThat(findToken).isEmpty();
     }
 }

--- a/src/test/java/com/kgu/studywithme/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/kgu/studywithme/auth/service/AuthServiceTest.java
@@ -1,0 +1,91 @@
+package com.kgu.studywithme.auth.service;
+
+import com.kgu.studywithme.auth.domain.Token;
+import com.kgu.studywithme.auth.service.dto.response.TokenResponse;
+import com.kgu.studywithme.auth.utils.JwtTokenProvider;
+import com.kgu.studywithme.common.ServiceTest;
+import com.kgu.studywithme.global.exception.StudyWithMeException;
+import com.kgu.studywithme.member.domain.Member;
+import com.kgu.studywithme.member.exception.MemberErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.kgu.studywithme.fixture.MemberFixture.SEO_JI_WON;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("Auth [Service Layer] -> AuthService 테스트")
+class AuthServiceTest extends ServiceTest {
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = SEO_JI_WON.toMember();
+        memberRepository.save(member);
+    }
+
+    @Nested
+    @DisplayName("로그인을 진행할 때 ")
+    class login {
+        @Test
+        @DisplayName("이메일에 해당하는 사용자가 존재하지 않으면 예외가 발생한다")
+        void wrongEmail() {
+            // given
+            final String email = "diff" + SEO_JI_WON.getEmail();
+            final String password = SEO_JI_WON.getPassword();
+            
+            // when - then
+            assertThatThrownBy(() -> authService.login(email, password))
+                    .isInstanceOf(StudyWithMeException.class)
+                    .hasMessage(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+        }
+        
+        @Test
+        @DisplayName("비밀번호가 일치하지 않으면 예외가 발생한다")
+        void wrongPassword() {
+            // given
+            final String email = SEO_JI_WON.getEmail();
+            final String password = "diff" + SEO_JI_WON.getPassword();
+            
+            // when - then
+            assertThatThrownBy(() -> authService.login(email, password))
+                    .isInstanceOf(StudyWithMeException.class)
+                    .hasMessage(MemberErrorCode.WRONG_PASSWORD.getMessage());
+        }
+        
+        @Test
+        @DisplayName("정보가 모두 일치하면 로그인에 성공하고 Access Token과 Refresh Token을 발급받는다")
+        void success() {
+            // given
+            final String email = SEO_JI_WON.getEmail();
+            final String password = SEO_JI_WON.getPassword();
+
+            // when
+            TokenResponse response = authService.login(email, password);
+
+            // then
+            assertAll(
+                    () -> assertThat(response).isNotNull(),
+                    () -> assertThat(response)
+                            .usingRecursiveComparison()
+                            .isNotNull(),
+                    () -> assertThat(jwtTokenProvider.getId(response.accessToken())).isEqualTo(member.getId()),
+                    () -> assertThat(jwtTokenProvider.getId(response.refreshToken())).isEqualTo(member.getId()),
+                    () -> {
+                        Token findToken = tokenRepository.findByMemberId(member.getId()).orElseThrow();
+                        assertThat(findToken.getRefreshToken()).isEqualTo(response.refreshToken());
+                    }
+            );
+        }
+    }
+}

--- a/src/test/java/com/kgu/studywithme/common/ControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/common/ControllerTest.java
@@ -2,7 +2,9 @@ package com.kgu.studywithme.common;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kgu.studywithme.auth.controller.AuthApiController;
 import com.kgu.studywithme.auth.controller.TokenReissueApiController;
+import com.kgu.studywithme.auth.service.AuthService;
 import com.kgu.studywithme.auth.service.TokenReissueService;
 import com.kgu.studywithme.auth.utils.JwtTokenProvider;
 import com.kgu.studywithme.member.controller.MemberApiController;
@@ -20,7 +22,8 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 
 @WebMvcTest({
         TokenReissueApiController.class,
-        MemberApiController.class
+        MemberApiController.class,
+        AuthApiController.class
 })
 @AutoConfigureRestDocs
 public abstract class ControllerTest {
@@ -38,6 +41,9 @@ public abstract class ControllerTest {
 
     @MockBean
     protected MemberSignUpService memberSignupService;
+
+    @MockBean
+    protected AuthService authService;
 
     protected OperationRequestPreprocessor applyRequestPreprocessor() {
         return Preprocessors.preprocessRequest(prettyPrint());

--- a/src/test/java/com/kgu/studywithme/member/domain/MemberRepositoryTest.java
+++ b/src/test/java/com/kgu/studywithme/member/domain/MemberRepositoryTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.Optional;
+
 import static com.kgu.studywithme.fixture.MemberFixture.SEO_JI_WON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -74,6 +76,24 @@ class MemberRepositoryTest extends RepositoryTest {
         assertAll(
                 () -> assertThat(actual1).isTrue(),
                 () -> assertThat(actual2).isFalse()
+        );
+    }
+
+    @Test
+    @DisplayName("이메일로 사용자를 조회한다")
+    void findByEmail() {
+        // given
+        final Email same = member.getEmail();
+        final Email diff = Email.from("diff" + member.getEmailValue());
+
+        // when
+        Optional<Member> findMember1 = memberRepository.findByEmail(same);
+        Optional<Member> findMember2 = memberRepository.findByEmail(diff);
+
+        // then
+        assertAll(
+                () -> assertThat(findMember1).isPresent(),
+                () -> assertThat(findMember2).isEmpty()
         );
     }
 }

--- a/src/test/java/com/kgu/studywithme/member/service/MemberFindServiceTest.java
+++ b/src/test/java/com/kgu/studywithme/member/service/MemberFindServiceTest.java
@@ -1,0 +1,46 @@
+package com.kgu.studywithme.member.service;
+
+import com.kgu.studywithme.common.ServiceTest;
+import com.kgu.studywithme.global.exception.StudyWithMeException;
+import com.kgu.studywithme.member.domain.Member;
+import com.kgu.studywithme.member.exception.MemberErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.kgu.studywithme.fixture.MemberFixture.SEO_JI_WON;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Member [Service Layer] -> MemberFindService 테스트")
+class MemberFindServiceTest extends ServiceTest {
+    @Autowired
+    private MemberFindService memberFindService;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = SEO_JI_WON.toMember();
+        memberRepository.save(member);
+    }
+
+    @Test
+    @DisplayName("이메일로 사용자를 조회한다")
+    void findByEmail() {
+        // given
+        final String same = member.getEmailValue();
+        final String diff = "diff" + member.getEmailValue();
+
+        // when
+        assertThatThrownBy(() -> memberFindService.findByEmail(diff))
+                .isInstanceOf(StudyWithMeException.class)
+                .hasMessage(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+
+        Member findMember = memberFindService.findByEmail(same);
+
+        // then
+        assertThat(findMember.getId()).isEqualTo(member.getId());
+    }
+}


### PR DESCRIPTION
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [X] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 정상적으로 프로그램이 동작하나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 로그인 로직 구현
    - 로그인 성공 시 <code>Access Token & Refresh Token</code>발급
- 로그아웃 로직 구현
    - 로그아웃 시 AccessToken의 Payload(memberId)에 해당하는 Refresh Token을 DB에서 삭제
- 테스트 코드 작성

Closes #20
