### PR TITLE
[refactor] 사용자 도메인에 React Avatar Url에 대한 필드를 추가한다

### DIFF
--- a/src/main/java/com/kgu/studywithme/auth/service/dto/response/LoginResponse.java
+++ b/src/main/java/com/kgu/studywithme/auth/service/dto/response/LoginResponse.java
@@ -1,10 +1,11 @@
 package com.kgu.studywithme.auth.service.dto.response;
 
-import com.kgu.studywithme.auth.infra.oauth.dto.response.GoogleUserResponse;
 import lombok.Builder;
 
 public record LoginResponse (
-        GoogleUserResponse userInfo, String accessToken, String refreshToken
+        MemberInfo member,
+        String accessToken,
+        String refreshToken
 ) {
     @Builder
     public LoginResponse {}

--- a/src/main/java/com/kgu/studywithme/auth/service/dto/response/MemberInfo.java
+++ b/src/main/java/com/kgu/studywithme/auth/service/dto/response/MemberInfo.java
@@ -1,0 +1,22 @@
+package com.kgu.studywithme.auth.service.dto.response;
+
+import com.kgu.studywithme.member.domain.Member;
+import lombok.Builder;
+
+public record MemberInfo(
+        Long id,
+        String nickname,
+        String email,
+        String profileUrl
+) {
+    @Builder
+    public MemberInfo {}
+
+    private MemberInfo(Member member) {
+        this(member.getId(), member.getNicknameValue(), member.getEmailValue(), member.getProfileUrl());
+    }
+
+    public static MemberInfo from(Member member) {
+        return new MemberInfo(member);
+    }
+}

--- a/src/main/java/com/kgu/studywithme/member/controller/dto/request/SignUpRequest.java
+++ b/src/main/java/com/kgu/studywithme/member/controller/dto/request/SignUpRequest.java
@@ -28,6 +28,9 @@ public record SignUpRequest(
         @NotBlank(message = "이메일은 필수입니다.")
         String email,
 
+        @NotBlank(message = "구글 프로필 URL은 필수입니다.")
+        String googleProfileUrl,
+
         @NotBlank(message = "프로필 URL은 필수입니다.")
         String profileUrl,
 
@@ -58,6 +61,7 @@ public record SignUpRequest(
                 .name(name)
                 .nickname(Nickname.from(nickname))
                 .email(Email.from(email))
+                .googleProflieUrl(googleProfileUrl)
                 .profileUrl(profileUrl)
                 .birth(birth)
                 .phone(phone)

--- a/src/main/java/com/kgu/studywithme/member/domain/Member.java
+++ b/src/main/java/com/kgu/studywithme/member/domain/Member.java
@@ -30,6 +30,9 @@ public class Member extends BaseEntity {
     @Embedded
     private Email email;
 
+    @Column(name = "google_profile_url", nullable = false)
+    private String googleProflieUrl;
+
     @Column(name = "profile_url", nullable = false)
     private String profileUrl;
 
@@ -56,11 +59,12 @@ public class Member extends BaseEntity {
     private Set<Category> interests = new HashSet<>();
 
     @Builder
-    private Member(String name, Nickname nickname, Email email, String profileUrl, LocalDate birth,
+    private Member(String name, Nickname nickname, Email email, String googleProflieUrl, String profileUrl, LocalDate birth,
                    String phone, Gender gender, Region region, Set<Category> interests) {
         this.name = name;
         this.nickname = nickname;
         this.email = email;
+        this.googleProflieUrl = googleProflieUrl;
         this.profileUrl = profileUrl;
         this.birth = birth;
         this.phone = phone;
@@ -69,9 +73,9 @@ public class Member extends BaseEntity {
         this.interests = interests;
     }
 
-    public static Member createMember(String name, Nickname nickname, Email email, String profileUrl, LocalDate birth,
+    public static Member createMember(String name, Nickname nickname, Email email, String googleProflieUrl, String profileUrl, LocalDate birth,
                                       String phone, Gender gender, Region region, Set<Category> interests) {
-        return new Member(name, nickname, email, profileUrl, birth, phone, gender, region, interests);
+        return new Member(name, nickname, email, googleProflieUrl, profileUrl, birth, phone, gender, region, interests);
     }
 
     public void changeNickname(String changeNickname) {

--- a/src/main/java/com/kgu/studywithme/member/domain/Member.java
+++ b/src/main/java/com/kgu/studywithme/member/domain/Member.java
@@ -82,6 +82,10 @@ public class Member extends BaseEntity {
         this.nickname = this.nickname.update(changeNickname);
     }
 
+    public void updateGoogleProfileUrl(String googleProflieUrl) {
+        this.googleProflieUrl = googleProflieUrl;
+    }
+
     public void updateInterests(Set<Category> interests) {
         this.interests.clear();
         this.interests.addAll(interests);

--- a/src/test/java/com/kgu/studywithme/auth/controller/OAuthApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/auth/controller/OAuthApiControllerTest.java
@@ -133,7 +133,7 @@ class OAuthApiControllerTest extends ControllerTest {
                                     responseFields(
                                             fieldWithPath("name").description("회원가입 진행 시 이름 기본값 [Read-Only]"),
                                             fieldWithPath("email").description("회원가입 진행 시 이메일 기본값 [Read-Only]"),
-                                            fieldWithPath("picture").description("회원가입 진행 시 사진 기본값")
+                                            fieldWithPath("picture").description("회원가입 진행 시 구글 프로필 이미지 기본값 [Read-Only]")
                                     )
                             )
                     );
@@ -157,12 +157,14 @@ class OAuthApiControllerTest extends ControllerTest {
             mockMvc.perform(requestBuilder)
                     .andExpectAll(
                             status().isOk(),
-                            jsonPath("$.userInfo.name").exists(),
-                            jsonPath("$.userInfo.name").value(JIWON.getName()),
-                            jsonPath("$.userInfo.email").exists(),
-                            jsonPath("$.userInfo.email").value(JIWON.getEmail()),
-                            jsonPath("$.userInfo.picture").exists(),
-                            jsonPath("$.userInfo.picture").value(JIWON.getProfileUrl()),
+                            jsonPath("$.member.id").exists(),
+                            jsonPath("$.member.id").value(1L),
+                            jsonPath("$.member.nickname").exists(),
+                            jsonPath("$.member.nickname").value(JIWON.getNickname()),
+                            jsonPath("$.member.email").exists(),
+                            jsonPath("$.member.email").value(JIWON.getEmail()),
+                            jsonPath("$.member.profileUrl").exists(),
+                            jsonPath("$.member.profileUrl").value(JIWON.getProfileUrl()),
                             jsonPath("$.accessToken").exists(),
                             jsonPath("$.accessToken").value(response.accessToken()),
                             jsonPath("$.refreshToken").exists(),
@@ -179,9 +181,10 @@ class OAuthApiControllerTest extends ControllerTest {
                                                     .attributes(constraint("Authorization Code 요청 시 redirectUrl과 반드시 동일한 값"))
                                     ),
                                     responseFields(
-                                            fieldWithPath("userInfo.name").description("사용자 이름"),
-                                            fieldWithPath("userInfo.email").description("사용자 이메일"),
-                                            fieldWithPath("userInfo.picture").description("사용자 프로필 이미지 링크"),
+                                            fieldWithPath("member.id").description("사용자 ID(PK)"),
+                                            fieldWithPath("member.nickname").description("사용자 닉네임"),
+                                            fieldWithPath("member.email").description("사용자 이메일"),
+                                            fieldWithPath("member.profileUrl").description("사용자 프로필 이미지 링크"),
                                             fieldWithPath("accessToken").description("발급된 Access Token (Expire - 2시간)"),
                                             fieldWithPath("refreshToken").description("발급된 Refresh Token (Expire - 2주)")
                                     )

--- a/src/test/java/com/kgu/studywithme/fixture/MemberFixture.java
+++ b/src/test/java/com/kgu/studywithme/fixture/MemberFixture.java
@@ -2,10 +2,12 @@ package com.kgu.studywithme.fixture;
 
 import com.kgu.studywithme.auth.infra.oauth.dto.response.GoogleUserResponse;
 import com.kgu.studywithme.auth.service.dto.response.LoginResponse;
+import com.kgu.studywithme.auth.service.dto.response.MemberInfo;
 import com.kgu.studywithme.category.domain.Category;
 import com.kgu.studywithme.member.domain.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.util.HashSet;
@@ -60,8 +62,11 @@ public enum MemberFixture {
     }
 
     public LoginResponse toLoginResponse() {
+        Member member = this.toMember();
+        ReflectionTestUtils.setField(member, "id", 1L);
+
         return LoginResponse.builder()
-                .userInfo(toGoogleUserResponse())
+                .member(MemberInfo.from(member))
                 .accessToken(ACCESS_TOKEN)
                 .refreshToken(REFRESH_TOKEN)
                 .build();

--- a/src/test/java/com/kgu/studywithme/fixture/MemberFixture.java
+++ b/src/test/java/com/kgu/studywithme/fixture/MemberFixture.java
@@ -18,17 +18,18 @@ import static com.kgu.studywithme.common.utils.TokenUtils.REFRESH_TOKEN;
 @Getter
 @RequiredArgsConstructor
 public enum MemberFixture {
-    JIWON("서지원", "서지원", "sjiwon4491@gmail.com", "profile_url", LocalDate.of(2000, 1, 18),
-            Gender.MALE, "경기도", "안양시", new HashSet<>(Set.of(LANGUAGE, INTERVIEW, PROGRAMMING))),
-    GHOST("고스트", "고스트", "ghost@gmail.com", "profile_url", LocalDate.of(2000, 1, 18),
-            Gender.MALE, "경기도", "안양시", new HashSet<>(Set.of(APTITUDE_NCS, CERTIFICATION, ETC))),
-    ANONYMOUS("익명", "익명", "anonymous@gmail.com", "profile_url", LocalDate.of(2000, 1, 18),
-            Gender.MALE, "경기도", "안양시", new HashSet<>(Set.of(APTITUDE_NCS, CERTIFICATION, ETC))),
+    JIWON("서지원", "서지원", "sjiwon4491@gmail.com", "google_profile_url", "https://source.boringavatars.com/beam/120/sjiwon4491@gmail.com",
+            LocalDate.of(2000, 1, 18), Gender.MALE, "경기도", "안양시", new HashSet<>(Set.of(LANGUAGE, INTERVIEW, PROGRAMMING))),
+    GHOST("고스트", "고스트", "ghost@gmail.com", "google_profile_url", "google_profile_url",
+            LocalDate.of(2000, 1, 18), Gender.MALE, "경기도", "안양시", new HashSet<>(Set.of(APTITUDE_NCS, CERTIFICATION, ETC))),
+    ANONYMOUS("익명", "익명", "anonymous@gmail.com", "google_profile_url", "https://source.boringavatars.com/beam/120/anonymous@gmail.com",
+            LocalDate.of(2000, 1, 18), Gender.MALE, "경기도", "안양시", new HashSet<>(Set.of(APTITUDE_NCS, CERTIFICATION, ETC))),
     ;
 
     private final String name;
     private final String nickname;
     private final String email;
+    private final String googleProflieUrl;
     private final String profileUrl;
     private final LocalDate birth;
     private final Gender gender;
@@ -41,6 +42,7 @@ public enum MemberFixture {
                 .name(name)
                 .nickname(Nickname.from(nickname))
                 .email(Email.from(email))
+                .googleProflieUrl(googleProflieUrl)
                 .profileUrl(profileUrl)
                 .birth(birth)
                 .phone(generateRandomPhoneNumber())

--- a/src/test/java/com/kgu/studywithme/member/controller/MemberApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/member/controller/MemberApiControllerTest.java
@@ -62,8 +62,10 @@ class MemberApiControllerTest extends ControllerTest {
                                             fieldWithPath("nickname").description("닉네임"),
                                             fieldWithPath("email").description("이메일")
                                                     .attributes(constraint("서버 제공 [Read-Only]")),
-                                            fieldWithPath("profileUrl").description("구글 프로필 이미지 URL")
+                                            fieldWithPath("googleProfileUrl").description("구글 프로필 이미지 URL")
                                                     .attributes(constraint("서버 제공 [Read-Only]")),
+                                            fieldWithPath("profileUrl").description("실제 선택한 이미지 URL")
+                                                    .attributes(constraint("구글 프로필 URL / 아바타 SVG URL")),
                                             fieldWithPath("birth").description("생년월일"),
                                             fieldWithPath("phone").description("전화번호"),
                                             fieldWithPath("gender").description("성별")
@@ -112,8 +114,10 @@ class MemberApiControllerTest extends ControllerTest {
                                             fieldWithPath("nickname").description("닉네임"),
                                             fieldWithPath("email").description("이메일")
                                                     .attributes(constraint("서버 제공 [Read-Only]")),
-                                            fieldWithPath("profileUrl").description("구글 프로필 이미지 URL")
+                                            fieldWithPath("googleProfileUrl").description("구글 프로필 이미지 URL")
                                                     .attributes(constraint("서버 제공 [Read-Only]")),
+                                            fieldWithPath("profileUrl").description("실제 선택한 이미지 URL")
+                                                    .attributes(constraint("구글 프로필 URL / 아바타 SVG URL")),
                                             fieldWithPath("birth").description("생년월일"),
                                             fieldWithPath("phone").description("전화번호"),
                                             fieldWithPath("gender").description("성별")

--- a/src/test/java/com/kgu/studywithme/member/controller/utils/SignUpRequestUtils.java
+++ b/src/test/java/com/kgu/studywithme/member/controller/utils/SignUpRequestUtils.java
@@ -16,6 +16,7 @@ public class SignUpRequestUtils {
                 .name(JIWON.getName())
                 .nickname(JIWON.getNickname())
                 .email(JIWON.getEmail())
+                .googleProfileUrl(JIWON.getGoogleProflieUrl())
                 .profileUrl(JIWON.getProfileUrl())
                 .birth(JIWON.getBirth())
                 .phone(generateRandomPhoneNumber())

--- a/src/test/java/com/kgu/studywithme/member/domain/MemberTest.java
+++ b/src/test/java/com/kgu/studywithme/member/domain/MemberTest.java
@@ -23,6 +23,7 @@ class MemberTest {
                 () -> assertThat(member.getName()).isEqualTo(JIWON.getName()),
                 () -> assertThat(member.getNicknameValue()).isEqualTo(JIWON.getNickname()),
                 () -> assertThat(member.getEmailValue()).isEqualTo(JIWON.getEmail()),
+                () -> assertThat(member.getGoogleProflieUrl()).isEqualTo(JIWON.getGoogleProflieUrl()),
                 () -> assertThat(member.getProfileUrl()).isEqualTo(JIWON.getProfileUrl()),
                 () -> assertThat(member.getBirth()).isEqualTo(JIWON.getBirth()),
                 () -> assertThat(member.getGender()).isEqualTo(JIWON.getGender()),

--- a/src/test/java/com/kgu/studywithme/member/domain/MemberTest.java
+++ b/src/test/java/com/kgu/studywithme/member/domain/MemberTest.java
@@ -62,6 +62,20 @@ class MemberTest {
     }
 
     @Test
+    @DisplayName("Google OAuth 통신에 의해 응답받은 사용자 프로필 이미지로 업데이트한다")
+    void updateGoogleProfileUrl() {
+        // given
+        Member member = JIWON.toMember();
+
+        // when
+        final String googleProfileUrl = "new_google_profile_url";
+        member.updateGoogleProfileUrl(googleProfileUrl);
+
+        // then
+        assertThat(member.getGoogleProflieUrl()).isEqualTo(googleProfileUrl);
+    }
+
+    @Test
     @DisplayName("이메일을 통해서 동일한 사용자인지 확인한다")
     void isSameMember() {
         // given

--- a/src/test/java/com/kgu/studywithme/member/service/MemberSignUpServiceTest.java
+++ b/src/test/java/com/kgu/studywithme/member/service/MemberSignUpServiceTest.java
@@ -99,6 +99,7 @@ class MemberSignUpServiceTest extends ServiceTest {
                 .name(JIWON.getName())
                 .nickname(Nickname.from(nickname))
                 .email(Email.from(email))
+                .googleProflieUrl(JIWON.getGoogleProflieUrl())
                 .profileUrl(JIWON.getProfileUrl())
                 .birth(JIWON.getBirth())
                 .phone(phone)


### PR DESCRIPTION
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [X] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 정상적으로 프로그램이 동작하나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 사용자 회원가입시 실제 선택한 프로필 URL에 대한 필드 추가
- 로그인 후 응답 스펙 수정
    - <code>MemberInfo</code> -> id, nickname, email, profileUrl
    - Access Token & Refresh Token

Closes #64
