### PR TITLE
[feat] 특정 스터디에 대한 참여 신청/승인/거부/취소 API를 구현한다

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -11,6 +11,6 @@ include::token-reissue.adoc[leveloffset=+1]
 
 include::member-signup.adoc[leveloffset=+1]
 
-include::category.adoc[leveloffset=+1
+include::category.adoc[leveloffset=+1]
 
 include::study-participation.adoc[leveloffset=+1]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -5,12 +5,12 @@
 :toc: left
 :toclevels: 3
 
-include::auth.adoc[leveloffset=+1]
-
 include::oauth.adoc[leveloffset=+1]
 
 include::token-reissue.adoc[leveloffset=+1]
 
 include::member-signup.adoc[leveloffset=+1]
 
-include::category.adoc[leveloffset=+1]
+include::category.adoc[leveloffset=+1
+
+include::study-participation.adoc[leveloffset=+1]

--- a/src/docs/asciidoc/study-participation.adoc
+++ b/src/docs/asciidoc/study-participation.adoc
@@ -1,0 +1,51 @@
+= 스터디 참여와 관련된 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+== 스터디 참여 신청
+=== 1. Authorization Header에 AccessToken이 없으면 스터디 참여 신청에 실패한다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Apply/Failure/Case1/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Apply/Failure/Case1/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Apply/Failure/Case1/response-body.adoc[]
+
+=== 2. 모집이 마감된 스터디에는 참여 신청을 할 수 없다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Apply/Failure/Case2/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Apply/Failure/Case2/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/Apply/Failure/Case2/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Apply/Failure/Case2/response-body.adoc[]
+
+=== 3. 스터디 팀장은 참여 신청을 할 수 없다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Apply/Failure/Case3/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Apply/Failure/Case3/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/Apply/Failure/Case3/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Apply/Failure/Case3/response-body.adoc[]
+
+=== 4. 이미 참여 신청을 했거나 참여중이라면 중복으로 참여 신청을 할 수 없다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Apply/Failure/Case4/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Apply/Failure/Case4/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/Apply/Failure/Case4/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Apply/Failure/Case4/response-body.adoc[]
+
+=== 5. 참여 신청에 성공한다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Apply/Success/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Apply/Success/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/Apply/Success/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Apply/Success/http-response.adoc[]

--- a/src/docs/asciidoc/study-participation.adoc
+++ b/src/docs/asciidoc/study-participation.adoc
@@ -175,3 +175,39 @@ include::{snippets}/StudyApi/Participation/Cancel/Success/path-parameters.adoc[]
 
 HTTP Response
 include::{snippets}/StudyApi/Participation/Cancel/Success/http-response.adoc[]
+
+== 스터디 팀장 권한 위임
+=== 1. Authorization Header에 AccessToken이 없으면 팀장 권한 위임에 실패한다
+HTTP Request
+include::{snippets}/StudyApi/Participation/DelegateAuthority/Failure/Case1/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/DelegateAuthority/Failure/Case1/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/DelegateAuthority/Failure/Case1/response-body.adoc[]
+
+=== 2. 스터디가 종료되었다면 팀장 권함을 위임할 수 없다
+HTTP Request
+include::{snippets}/StudyApi/Participation/DelegateAuthority/Failure/Case2/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/DelegateAuthority/Failure/Case2/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/DelegateAuthority/Failure/Case2/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/DelegateAuthority/Failure/Case2/response-body.adoc[]
+
+=== 3. 참여자가 아니면 팀장 권한을 위임할 수 없다
+HTTP Request
+include::{snippets}/StudyApi/Participation/DelegateAuthority/Failure/Case3/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/DelegateAuthority/Failure/Case3/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/DelegateAuthority/Failure/Case3/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/DelegateAuthority/Failure/Case3/response-body.adoc[]
+
+=== 5. 팀장 권한 위임에 성공한다
+HTTP Request
+include::{snippets}/StudyApi/Participation/DelegateAuthority/Success/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/DelegateAuthority/Success/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/DelegateAuthority/Success/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/DelegateAuthority/Success/http-response.adoc[]

--- a/src/docs/asciidoc/study-participation.adoc
+++ b/src/docs/asciidoc/study-participation.adoc
@@ -49,3 +49,48 @@ include::{snippets}/StudyApi/Participation/Apply/Success/path-parameters.adoc[]
 
 HTTP Response
 include::{snippets}/StudyApi/Participation/Apply/Success/http-response.adoc[]
+
+== 스터디 참여 승인
+=== 1. Authorization Header에 AccessToken이 없으면 스터디 참여 승인에 실패한다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Approve/Failure/Case1/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Approve/Failure/Case1/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Approve/Failure/Case1/response-body.adoc[]
+
+=== 2. 스터디가 종료되었다면 더이상 참여 승인을 할 수 없다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Approve/Failure/Case2/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Approve/Failure/Case2/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/Approve/Failure/Case2/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Approve/Failure/Case2/response-body.adoc[]
+
+=== 3. 참여 신청자가 아니면 참여 승인을 할 수 없다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Approve/Failure/Case3/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Approve/Failure/Case3/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/Approve/Failure/Case3/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Approve/Failure/Case3/response-body.adoc[]
+
+=== 4. 참여 인원이 꽉 찼다면 더이상 참여 승인을 할 수 없다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Approve/Failure/Case4/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Approve/Failure/Case4/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/Approve/Failure/Case4/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Approve/Failure/Case4/response-body.adoc[]
+
+=== 5. 참여 승인에 성공한다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Approve/Success/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Approve/Success/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/Approve/Success/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Approve/Success/http-response.adoc[]

--- a/src/docs/asciidoc/study-participation.adoc
+++ b/src/docs/asciidoc/study-participation.adoc
@@ -122,7 +122,7 @@ include::{snippets}/StudyApi/Participation/Reject/Failure/Case3/path-parameters.
 HTTP Response
 include::{snippets}/StudyApi/Participation/Reject/Failure/Case3/response-body.adoc[]
 
-=== 4. 참여 거절 성공한다
+=== 4. 참여 거절을 성공한다
 HTTP Request
 include::{snippets}/StudyApi/Participation/Reject/Success/http-request.adoc[]
 include::{snippets}/StudyApi/Participation/Reject/Success/request-headers.adoc[]
@@ -130,3 +130,48 @@ include::{snippets}/StudyApi/Participation/Reject/Success/path-parameters.adoc[]
 
 HTTP Response
 include::{snippets}/StudyApi/Participation/Reject/Success/http-response.adoc[]
+
+== 스터디 참여 취소
+=== 1. Authorization Header에 AccessToken이 없으면 스터디 참여 취소에 실패한다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Cancel/Failure/Case1/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Cancel/Failure/Case1/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Cancel/Failure/Case1/response-body.adoc[]
+
+=== 2. 스터디가 종료되었다면 더이상 참여 취소를 할 수 없다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Cancel/Failure/Case2/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Cancel/Failure/Case2/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/Cancel/Failure/Case2/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Cancel/Failure/Case2/response-body.adoc[]
+
+=== 3. 스터디 팀장은 참여 취소를 할 수 없다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Cancel/Failure/Case3/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Cancel/Failure/Case3/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/Cancel/Failure/Case3/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Cancel/Failure/Case3/response-body.adoc[]
+
+=== 4. 참여자가 아니면 참여 취소를 할 수 없다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Cancel/Failure/Case4/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Cancel/Failure/Case4/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/Cancel/Failure/Case4/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Cancel/Failure/Case4/response-body.adoc[]
+
+=== 5. 참여 취소에 성공한다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Cancel/Success/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Cancel/Success/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/Cancel/Success/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Cancel/Success/http-response.adoc[]

--- a/src/docs/asciidoc/study-participation.adoc
+++ b/src/docs/asciidoc/study-participation.adoc
@@ -94,3 +94,39 @@ include::{snippets}/StudyApi/Participation/Approve/Success/path-parameters.adoc[
 
 HTTP Response
 include::{snippets}/StudyApi/Participation/Approve/Success/http-response.adoc[]
+
+== 스터디 참여 거절
+=== 1. Authorization Header에 AccessToken이 없으면 스터디 참여 거절에 실패한다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case1/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case1/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case1/response-body.adoc[]
+
+=== 2. 스터디가 종료되었다면 더이상 참여 거절을 할 수 없다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case2/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case2/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case2/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case2/response-body.adoc[]
+
+=== 3. 참여 신청자가 아니면 참여 거절을 할 수 없다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case3/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case3/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case3/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case3/response-body.adoc[]
+
+=== 4. 참여 거절 성공한다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Reject/Success/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Reject/Success/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/Reject/Success/path-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Reject/Success/http-response.adoc[]

--- a/src/main/java/com/kgu/studywithme/member/service/MemberFindService.java
+++ b/src/main/java/com/kgu/studywithme/member/service/MemberFindService.java
@@ -15,6 +15,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberFindService {
     private final MemberRepository memberRepository;
 
+    public Member findById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> StudyWithMeException.type(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
     public Member findByEmail(String email) {
         return memberRepository.findByEmail(Email.from(email))
                 .orElseThrow(() -> StudyWithMeException.type(MemberErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/kgu/studywithme/study/controller/StudyParticipationApiController.java
+++ b/src/main/java/com/kgu/studywithme/study/controller/StudyParticipationApiController.java
@@ -23,4 +23,10 @@ public class StudyParticipationApiController {
         participationService.approve(studyId, applierId, hostId);
         return ResponseEntity.noContent().build();
     }
+
+    @PatchMapping("/applicants/{applierId}/reject")
+    public ResponseEntity<Void> reject(@PathVariable Long studyId, @PathVariable Long applierId, @ExtractPayload Long hostId) {
+        participationService.reject(studyId, applierId, hostId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/kgu/studywithme/study/controller/StudyParticipationApiController.java
+++ b/src/main/java/com/kgu/studywithme/study/controller/StudyParticipationApiController.java
@@ -1,0 +1,23 @@
+package com.kgu.studywithme.study.controller;
+
+import com.kgu.studywithme.global.annotation.ExtractPayload;
+import com.kgu.studywithme.study.service.ParticipationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/studies/{studyId}")
+public class StudyParticipationApiController {
+    private final ParticipationService participationService;
+
+    @PostMapping("/applicants")
+    public ResponseEntity<Void> apply(@PathVariable Long studyId, @ExtractPayload Long memberId) {
+        participationService.apply(studyId, memberId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/kgu/studywithme/study/controller/StudyParticipationApiController.java
+++ b/src/main/java/com/kgu/studywithme/study/controller/StudyParticipationApiController.java
@@ -4,10 +4,7 @@ import com.kgu.studywithme.global.annotation.ExtractPayload;
 import com.kgu.studywithme.study.service.ParticipationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,6 +15,12 @@ public class StudyParticipationApiController {
     @PostMapping("/applicants")
     public ResponseEntity<Void> apply(@PathVariable Long studyId, @ExtractPayload Long memberId) {
         participationService.apply(studyId, memberId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/applicants/{applierId}/approve")
+    public ResponseEntity<Void> approve(@PathVariable Long studyId, @PathVariable Long applierId, @ExtractPayload Long hostId) {
+        participationService.approve(studyId, applierId, hostId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/kgu/studywithme/study/controller/StudyParticipationApiController.java
+++ b/src/main/java/com/kgu/studywithme/study/controller/StudyParticipationApiController.java
@@ -29,4 +29,10 @@ public class StudyParticipationApiController {
         participationService.reject(studyId, applierId, hostId);
         return ResponseEntity.noContent().build();
     }
+
+    @PatchMapping("/participants/cancel")
+    public ResponseEntity<Void> cancel(@PathVariable Long studyId, @ExtractPayload Long participantId) {
+        participationService.cancel(studyId, participantId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/kgu/studywithme/study/controller/StudyParticipationApiController.java
+++ b/src/main/java/com/kgu/studywithme/study/controller/StudyParticipationApiController.java
@@ -35,4 +35,10 @@ public class StudyParticipationApiController {
         participationService.cancel(studyId, participantId);
         return ResponseEntity.noContent().build();
     }
+
+    @PatchMapping("/participants/{participantId}/delegation")
+    public ResponseEntity<Void> delegateAuthority(@PathVariable Long studyId, @PathVariable Long participantId, @ExtractPayload Long hostId) {
+        participationService.delegateAuthority(studyId, participantId, hostId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/kgu/studywithme/study/domain/Study.java
+++ b/src/main/java/com/kgu/studywithme/study/domain/Study.java
@@ -123,6 +123,7 @@ public class Study extends BaseEntity {
     }
 
     public void delegateStudyHostAuthority(Member newHost) {
+        validateStudyIsProceeding();
         participants.delegateStudyHostAuthority(newHost);
     }
 

--- a/src/main/java/com/kgu/studywithme/study/domain/StudyRepository.java
+++ b/src/main/java/com/kgu/studywithme/study/domain/StudyRepository.java
@@ -12,4 +12,10 @@ public interface StudyRepository extends JpaRepository<Study, Long> {
             " JOIN FETCH s.participants.host" +
             " WHERE s.id = :studyId")
     Optional<Study> findByIdWithHost(@Param("studyId") Long studyId);
+
+    @Query("SELECT s" +
+            " FROM Study s" +
+            " JOIN FETCH s.participants.host h" +
+            " WHERE s.id = :studyId AND h.id = :hostId")
+    Optional<Study> findByIdAndHostId(@Param("studyId") Long studyId, @Param("hostId") Long hostId);
 }

--- a/src/main/java/com/kgu/studywithme/study/domain/StudyRepository.java
+++ b/src/main/java/com/kgu/studywithme/study/domain/StudyRepository.java
@@ -1,6 +1,15 @@
 package com.kgu.studywithme.study.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface StudyRepository extends JpaRepository<Study, Long> {
+    @Query("SELECT s" +
+            " FROM Study s" +
+            " JOIN FETCH s.participants.host" +
+            " WHERE s.id = :studyId")
+    Optional<Study> findByIdWithHost(@Param("studyId") Long studyId);
 }

--- a/src/main/java/com/kgu/studywithme/study/exception/StudyErrorCode.java
+++ b/src/main/java/com/kgu/studywithme/study/exception/StudyErrorCode.java
@@ -30,6 +30,7 @@ public enum StudyErrorCode implements ErrorCode {
     PERIOD_START_DATE_MUST_BE_BEFORE_END_DATE(HttpStatus.CONFLICT, "STUDY_012", "과제 제출 기간의 시작일은 종료일 이전이어야 합니다."),
     PERIOD_END_DATE_MUST_BE_SET_FROM_NOW_ON(HttpStatus.CONFLICT, "STUDY_012", "종료일은 과거일 수 없습니다."),
     ALREADY_ASSIGNMENT_EXISTS_PER_WEEK(HttpStatus.CONFLICT, "STUDY_013", "해당 주차에는 이미 과제가 등록되어 있습니다."),
+    STUDY_NOT_FOUND(HttpStatus.CONFLICT, "STUDY_015", "스터디가 존재하지 않습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/kgu/studywithme/study/service/ParticipationService.java
+++ b/src/main/java/com/kgu/studywithme/study/service/ParticipationService.java
@@ -21,4 +21,12 @@ public class ParticipationService {
 
         study.applyParticipation(member);
     }
+
+    @Transactional
+    public void approve(Long studyId, Long applierId, Long hostId) {
+        Study study = studyFindService.findByIdAndHostId(studyId, hostId);
+        Member applier = memberFindService.findById(applierId);
+
+        study.approveParticipation(applier);
+    }
 }

--- a/src/main/java/com/kgu/studywithme/study/service/ParticipationService.java
+++ b/src/main/java/com/kgu/studywithme/study/service/ParticipationService.java
@@ -45,4 +45,12 @@ public class ParticipationService {
 
         study.cancelParticipation(participant);
     }
+
+    @Transactional
+    public void delegateAuthority(Long studyId, Long participantId, Long hostId) {
+        Study study = studyFindService.findByIdAndHostId(studyId, hostId);
+        Member newHost = memberFindService.findById(participantId);
+
+        study.delegateStudyHostAuthority(newHost);
+    }
 }

--- a/src/main/java/com/kgu/studywithme/study/service/ParticipationService.java
+++ b/src/main/java/com/kgu/studywithme/study/service/ParticipationService.java
@@ -29,4 +29,12 @@ public class ParticipationService {
 
         study.approveParticipation(applier);
     }
+
+    @Transactional
+    public void reject(Long studyId, Long applierId, Long hostId) {
+        Study study = studyFindService.findByIdAndHostId(studyId, hostId);
+        Member applier = memberFindService.findById(applierId);
+
+        study.rejectParticipation(applier);
+    }
 }

--- a/src/main/java/com/kgu/studywithme/study/service/ParticipationService.java
+++ b/src/main/java/com/kgu/studywithme/study/service/ParticipationService.java
@@ -1,0 +1,24 @@
+package com.kgu.studywithme.study.service;
+
+import com.kgu.studywithme.member.domain.Member;
+import com.kgu.studywithme.member.service.MemberFindService;
+import com.kgu.studywithme.study.domain.Study;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ParticipationService {
+    private final StudyFindService studyFindService;
+    private final MemberFindService memberFindService;
+
+    @Transactional
+    public void apply(Long studyId, Long memberId) {
+        Study study = studyFindService.findByIdWithHost(studyId);
+        Member member = memberFindService.findById(memberId);
+
+        study.applyParticipation(member);
+    }
+}

--- a/src/main/java/com/kgu/studywithme/study/service/ParticipationService.java
+++ b/src/main/java/com/kgu/studywithme/study/service/ParticipationService.java
@@ -37,4 +37,12 @@ public class ParticipationService {
 
         study.rejectParticipation(applier);
     }
+
+    @Transactional
+    public void cancel(Long studyId, Long participantId) {
+        Study study = studyFindService.findByIdWithHost(studyId);
+        Member participant = memberFindService.findById(participantId);
+
+        study.cancelParticipation(participant);
+    }
 }

--- a/src/main/java/com/kgu/studywithme/study/service/StudyFindService.java
+++ b/src/main/java/com/kgu/studywithme/study/service/StudyFindService.java
@@ -14,13 +14,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class StudyFindService {
     private final StudyRepository studyRepository;
 
-    public Study findById(Long studyId) {
-        return studyRepository.findById(studyId)
+    public Study findByIdWithHost(Long studyId) {
+        return studyRepository.findByIdWithHost(studyId)
                 .orElseThrow(() -> StudyWithMeException.type(StudyErrorCode.STUDY_NOT_FOUND));
     }
 
-    public Study findByIdWithHost(Long studyId) {
-        return studyRepository.findByIdWithHost(studyId)
+    public Study findByIdAndHostId(Long studyId, Long hostId) {
+        return studyRepository.findByIdAndHostId(studyId, hostId)
                 .orElseThrow(() -> StudyWithMeException.type(StudyErrorCode.STUDY_NOT_FOUND));
     }
 }

--- a/src/main/java/com/kgu/studywithme/study/service/StudyFindService.java
+++ b/src/main/java/com/kgu/studywithme/study/service/StudyFindService.java
@@ -1,0 +1,26 @@
+package com.kgu.studywithme.study.service;
+
+import com.kgu.studywithme.global.exception.StudyWithMeException;
+import com.kgu.studywithme.study.domain.Study;
+import com.kgu.studywithme.study.domain.StudyRepository;
+import com.kgu.studywithme.study.exception.StudyErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class StudyFindService {
+    private final StudyRepository studyRepository;
+
+    public Study findById(Long studyId) {
+        return studyRepository.findById(studyId)
+                .orElseThrow(() -> StudyWithMeException.type(StudyErrorCode.STUDY_NOT_FOUND));
+    }
+
+    public Study findByIdWithHost(Long studyId) {
+        return studyRepository.findByIdWithHost(studyId)
+                .orElseThrow(() -> StudyWithMeException.type(StudyErrorCode.STUDY_NOT_FOUND));
+    }
+}

--- a/src/test/java/com/kgu/studywithme/common/ControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/common/ControllerTest.java
@@ -12,6 +12,8 @@ import com.kgu.studywithme.category.controller.CategoryApiController;
 import com.kgu.studywithme.category.service.CategoryService;
 import com.kgu.studywithme.member.controller.MemberApiController;
 import com.kgu.studywithme.member.service.MemberSignUpService;
+import com.kgu.studywithme.study.controller.StudyParticipationApiController;
+import com.kgu.studywithme.study.service.ParticipationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +39,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
         TokenReissueApiController.class,
         MemberApiController.class,
         OAuthApiController.class,
-        CategoryApiController.class
+        CategoryApiController.class,
+        StudyParticipationApiController.class
 })
 @ExtendWith(RestDocumentationExtension.class)
 @AutoConfigureRestDocs
@@ -65,6 +68,9 @@ public abstract class ControllerTest {
 
     @MockBean
     protected CategoryService categoryService;
+
+    @MockBean
+    protected ParticipationService participationService;
 
     @BeforeEach
     void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {

--- a/src/test/java/com/kgu/studywithme/common/ServiceTest.java
+++ b/src/test/java/com/kgu/studywithme/common/ServiceTest.java
@@ -3,6 +3,7 @@ package com.kgu.studywithme.common;
 import com.kgu.studywithme.auth.domain.TokenRepository;
 import com.kgu.studywithme.auth.utils.JwtTokenProvider;
 import com.kgu.studywithme.member.domain.MemberRepository;
+import com.kgu.studywithme.study.domain.StudyRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -22,6 +23,9 @@ public class ServiceTest {
 
     @Autowired
     protected TokenRepository tokenRepository;
+
+    @Autowired
+    protected StudyRepository studyRepository;
 
     @AfterEach
     void clearDatabase() {

--- a/src/test/java/com/kgu/studywithme/member/service/MemberFindServiceTest.java
+++ b/src/test/java/com/kgu/studywithme/member/service/MemberFindServiceTest.java
@@ -26,6 +26,20 @@ class MemberFindServiceTest extends ServiceTest {
     }
 
     @Test
+    @DisplayName("ID(PK)로 사용자를 조회한다")
+    void findById() {
+        // when
+        assertThatThrownBy(() -> memberFindService.findById(member.getId() + 10000L))
+                .isInstanceOf(StudyWithMeException.class)
+                .hasMessage(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+
+        Member findMember = memberFindService.findById(member.getId());
+
+        // then
+        assertThat(findMember).isEqualTo(member);
+    }
+
+    @Test
     @DisplayName("이메일로 사용자를 조회한다")
     void findByEmail() {
         // given
@@ -40,6 +54,6 @@ class MemberFindServiceTest extends ServiceTest {
         Member findMember = memberFindService.findByEmail(same);
 
         // then
-        assertThat(findMember.getId()).isEqualTo(member.getId());
+        assertThat(findMember).isEqualTo(member);
     }
 }

--- a/src/test/java/com/kgu/studywithme/study/controller/StudyParticipationApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/study/controller/StudyParticipationApiControllerTest.java
@@ -1,0 +1,252 @@
+package com.kgu.studywithme.study.controller;
+
+import com.kgu.studywithme.auth.exception.AuthErrorCode;
+import com.kgu.studywithme.common.ControllerTest;
+import com.kgu.studywithme.global.exception.StudyWithMeException;
+import com.kgu.studywithme.study.exception.StudyErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import static com.kgu.studywithme.common.utils.TokenUtils.ACCESS_TOKEN;
+import static com.kgu.studywithme.common.utils.TokenUtils.BEARER_TOKEN;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Study [Controller Layer] -> StudyParticipationApiController 테스트")
+class StudyParticipationApiControllerTest extends ControllerTest {
+    @Nested
+    @DisplayName("스터디 참여 신청 API [POST /api/studies/{studyId}/applicants]")
+    class apply {
+        private static final String BASE_URL = "/api/studies/{studyId}/applicants";
+        private static final Long STUDY_ID = 1L;
+
+        @Test
+        @DisplayName("Authorization Header에 AccessToken이 없으면 스터디 참여 신청에 실패한다")
+        void withoutAccessToken() throws Exception {
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .post(BASE_URL, STUDY_ID);
+
+            // then
+            final AuthErrorCode expectedError = AuthErrorCode.INVALID_PERMISSION;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isForbidden(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "StudyApi/Participation/Apply/Failure/Case1",
+                                    getDocumentRequest(),
+                                    getDocumentResponse(),
+                                    pathParameters(
+                                            parameterWithName("studyId").description("참여 신청을 진행할 스터디 ID(PK)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("모집이 마감된 스터디에는 참여 신청을 할 수 없다")
+        void failureByRecruitmentCompleted() throws Exception {
+            // given
+            given(jwtTokenProvider.isTokenValid(anyString())).willReturn(true);
+            given(jwtTokenProvider.getId(anyString())).willReturn(1L);
+            doThrow(StudyWithMeException.type(StudyErrorCode.RECRUITMENT_IS_COMPLETE))
+                    .when(participationService)
+                    .apply(anyLong(), anyLong());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .post(BASE_URL, STUDY_ID)
+                    .header(AUTHORIZATION, String.join(" ", BEARER_TOKEN, ACCESS_TOKEN));
+
+            // then
+            final StudyErrorCode expectedError = StudyErrorCode.RECRUITMENT_IS_COMPLETE;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isConflict(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "StudyApi/Participation/Apply/Failure/Case2",
+                                    getDocumentRequest(),
+                                    getDocumentResponse(),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    pathParameters(
+                                            parameterWithName("studyId").description("참여 신청을 진행할 스터디 ID(PK)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("스터디 팀장은 참여 신청을 할 수 없다")
+        void failureByHost() throws Exception {
+            // given
+            given(jwtTokenProvider.isTokenValid(anyString())).willReturn(true);
+            given(jwtTokenProvider.getId(anyString())).willReturn(1L);
+            doThrow(StudyWithMeException.type(StudyErrorCode.MEMBER_IS_HOST))
+                    .when(participationService)
+                    .apply(anyLong(), anyLong());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .post(BASE_URL, STUDY_ID)
+                    .header(AUTHORIZATION, String.join(" ", BEARER_TOKEN, ACCESS_TOKEN));
+
+            // then
+            final StudyErrorCode expectedError = StudyErrorCode.MEMBER_IS_HOST;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isConflict(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "StudyApi/Participation/Apply/Failure/Case3",
+                                    getDocumentRequest(),
+                                    getDocumentResponse(),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    pathParameters(
+                                            parameterWithName("studyId").description("참여 신청을 진행할 스터디 ID(PK)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("이미 참여 신청을 했거나 참여중이라면 중복으로 참여 신청을 할 수 없다")
+        void failureByAlreadyApply() throws Exception {
+            // given
+            given(jwtTokenProvider.isTokenValid(anyString())).willReturn(true);
+            given(jwtTokenProvider.getId(anyString())).willReturn(1L);
+            doThrow(StudyWithMeException.type(StudyErrorCode.MEMBER_IS_PARTICIPANT))
+                    .when(participationService)
+                    .apply(anyLong(), anyLong());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .post(BASE_URL, STUDY_ID)
+                    .header(AUTHORIZATION, String.join(" ", BEARER_TOKEN, ACCESS_TOKEN));
+
+            // then
+            final StudyErrorCode expectedError = StudyErrorCode.MEMBER_IS_PARTICIPANT;
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isConflict(),
+                            jsonPath("$.status").exists(),
+                            jsonPath("$.status").value(expectedError.getStatus().value()),
+                            jsonPath("$.errorCode").exists(),
+                            jsonPath("$.errorCode").value(expectedError.getErrorCode()),
+                            jsonPath("$.message").exists(),
+                            jsonPath("$.message").value(expectedError.getMessage())
+                    )
+                    .andDo(
+                            document(
+                                    "StudyApi/Participation/Apply/Failure/Case4",
+                                    getDocumentRequest(),
+                                    getDocumentResponse(),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    pathParameters(
+                                            parameterWithName("studyId").description("참여 신청을 진행할 스터디 ID(PK)")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("status").description("HTTP 상태 코드"),
+                                            fieldWithPath("errorCode").description("커스텀 예외 코드"),
+                                            fieldWithPath("message").description("예외 메시지")
+                                    )
+                            )
+                    );
+        }
+
+        @Test
+        @DisplayName("참여 신청에 성공한다")
+        void success() throws Exception {
+            // given
+            given(jwtTokenProvider.isTokenValid(anyString())).willReturn(true);
+            given(jwtTokenProvider.getId(anyString())).willReturn(1L);
+            doNothing()
+                    .when(participationService)
+                    .apply(anyLong(), anyLong());
+
+            // when
+            MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
+                    .post(BASE_URL, STUDY_ID)
+                    .header(AUTHORIZATION, String.join(" ", BEARER_TOKEN, ACCESS_TOKEN));
+
+            // then
+            mockMvc.perform(requestBuilder)
+                    .andExpectAll(
+                            status().isNoContent(),
+                            jsonPath("$").doesNotExist()
+                    )
+                    .andDo(
+                            document(
+                                    "StudyApi/Participation/Apply/Success",
+                                    getDocumentRequest(),
+                                    getDocumentResponse(),
+                                    requestHeaders(
+                                            headerWithName(AUTHORIZATION).description("Access Token")
+                                    ),
+                                    pathParameters(
+                                            parameterWithName("studyId").description("참여 신청을 진행할 스터디 ID(PK)")
+                                    )
+                            )
+                    );
+        }
+    }
+}

--- a/src/test/java/com/kgu/studywithme/study/domain/StudyRepositoryTest.java
+++ b/src/test/java/com/kgu/studywithme/study/domain/StudyRepositoryTest.java
@@ -42,4 +42,17 @@ class StudyRepositoryTest extends RepositoryTest {
                 () -> assertThat(findStudy.getHost()).isEqualTo(host)
         );
     }
+
+    @Test
+    @DisplayName("스터디 ID + 팀장 ID로 스터디를 조회한다")
+    void findByIdAndHostId() {
+        // when
+        Study findStudy = studyRepository.findByIdAndHostId(study.getId(), host.getId()).orElseThrow();
+
+        // then
+        assertAll(
+                () -> assertThat(findStudy).isEqualTo(study),
+                () -> assertThat(findStudy.getHost()).isEqualTo(host)
+        );
+    }
 }

--- a/src/test/java/com/kgu/studywithme/study/domain/StudyRepositoryTest.java
+++ b/src/test/java/com/kgu/studywithme/study/domain/StudyRepositoryTest.java
@@ -1,0 +1,45 @@
+package com.kgu.studywithme.study.domain;
+
+import com.kgu.studywithme.common.RepositoryTest;
+import com.kgu.studywithme.member.domain.Member;
+import com.kgu.studywithme.member.domain.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.kgu.studywithme.fixture.MemberFixture.JIWON;
+import static com.kgu.studywithme.fixture.StudyFixture.SPRING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("Study [Repository Layer] -> StudyRepository 테스트")
+class StudyRepositoryTest extends RepositoryTest {
+    @Autowired
+    private StudyRepository studyRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member host;
+    private Study study;
+
+    @BeforeEach
+    void setUp() {
+        host = memberRepository.save(JIWON.toMember());
+        study = studyRepository.save(SPRING.toStudy(host));
+    }
+
+    @Test
+    @DisplayName("스터디를 조회한다 [With Host]")
+    void findByIdWithHost() {
+        // when
+        Study findStudy = studyRepository.findByIdWithHost(study.getId()).orElseThrow();
+
+        // then
+        assertAll(
+                () -> assertThat(findStudy).isEqualTo(study),
+                () -> assertThat(findStudy.getHost()).isEqualTo(host)
+        );
+    }
+}

--- a/src/test/java/com/kgu/studywithme/study/service/ParticipationServiceTest.java
+++ b/src/test/java/com/kgu/studywithme/study/service/ParticipationServiceTest.java
@@ -1,0 +1,88 @@
+package com.kgu.studywithme.study.service;
+
+import com.kgu.studywithme.common.ServiceTest;
+import com.kgu.studywithme.global.exception.StudyWithMeException;
+import com.kgu.studywithme.member.domain.Member;
+import com.kgu.studywithme.study.domain.Study;
+import com.kgu.studywithme.study.exception.StudyErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.kgu.studywithme.fixture.MemberFixture.GHOST;
+import static com.kgu.studywithme.fixture.MemberFixture.JIWON;
+import static com.kgu.studywithme.fixture.StudyFixture.SPRING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("Study [Service Layer] -> ParticipationService 테스트")
+class ParticipationServiceTest extends ServiceTest {
+    @Autowired
+    private ParticipationService participationService;
+
+    @Nested
+    @DisplayName("스터디 참여 신청")
+    class apply {
+        private Member host;
+        private Member participant;
+        private Study study;
+
+        @BeforeEach
+        void setUp() {
+            host = memberRepository.save(JIWON.toMember());
+            participant = memberRepository.save(GHOST.toMember());
+            study = studyRepository.save(SPRING.toStudy(host));
+        }
+
+        @Test
+        @DisplayName("모집이 마감된 스터디에는 참여 신청을 할 수 없다")
+        void failureByRecruitmentCompleted() {
+            // given
+            study.completeRecruitment();
+
+            // when - then
+            assertThatThrownBy(() -> participationService.apply(study.getId(), participant.getId()))
+                    .isInstanceOf(StudyWithMeException.class)
+                    .hasMessage(StudyErrorCode.RECRUITMENT_IS_COMPLETE.getMessage());
+        }
+        
+        @Test
+        @DisplayName("스터디 팀장은 참여 신청을 할 수 없다")
+        void failureByHost() {
+            assertThatThrownBy(() -> participationService.apply(study.getId(), host.getId()))
+                    .isInstanceOf(StudyWithMeException.class)
+                    .hasMessage(StudyErrorCode.MEMBER_IS_HOST.getMessage());
+        }
+
+        @Test
+        @DisplayName("이미 참여 신청을 했거나 참여중이라면 중복으로 참여 신청을 할 수 없다")
+        void failureByAlreadyApply() {
+            // given
+            study.applyParticipation(participant);
+
+            // when - then
+            assertThatThrownBy(() -> participationService.apply(study.getId(), participant.getId()))
+                    .isInstanceOf(StudyWithMeException.class)
+                    .hasMessage(StudyErrorCode.MEMBER_IS_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        @DisplayName("참여 신청에 성공한다")
+        void success() {
+            // when
+            participationService.apply(study.getId(), participant.getId());
+
+            // then
+            Study findStudy = studyRepository.findById(study.getId()).orElseThrow();
+            assertAll(
+                    () -> assertThat(findStudy.getParticipants().size()).isEqualTo(2),
+                    () -> assertThat(findStudy.getParticipants()).containsExactly(host, participant),
+                    () -> assertThat(findStudy.getApproveParticipants().size()).isEqualTo(1),
+                    () -> assertThat(findStudy.getApproveParticipants()).containsExactly(host)
+            );
+        }
+    }
+}

--- a/src/test/java/com/kgu/studywithme/study/service/ParticipationServiceTest.java
+++ b/src/test/java/com/kgu/studywithme/study/service/ParticipationServiceTest.java
@@ -211,4 +211,69 @@ class ParticipationServiceTest extends ServiceTest {
             );
         }
     }
+
+    @Nested
+    @DisplayName("스터디 참여 취소")
+    class cancel {
+        private Member host;
+        private Member participant;
+        private Study study;
+
+        @BeforeEach
+        void setUp() {
+            host = memberRepository.save(JIWON.toMember());
+            participant = memberRepository.save(GHOST.toMember());
+            study = studyRepository.save(SPRING.toStudy(host));
+        }
+
+        @Test
+        @DisplayName("스터디가 종료되었다면 더이상 참여 취소를 할 수 없다")
+        void failureByStudyClosed() {
+            // given
+            study.applyParticipation(participant);
+            study.approveParticipation(participant);
+            study.close();
+
+            // when - then
+            assertThatThrownBy(() -> participationService.cancel(study.getId(), participant.getId()))
+                    .isInstanceOf(StudyWithMeException.class)
+                    .hasMessage(StudyErrorCode.ALREADY_CLOSED.getMessage());
+        }
+
+        @Test
+        @DisplayName("스터디 팀장은 참여 취소를 할 수 없다")
+        void failureByHost() {
+            assertThatThrownBy(() -> participationService.cancel(study.getId(), host.getId()))
+                    .isInstanceOf(StudyWithMeException.class)
+                    .hasMessage(StudyErrorCode.MEMBER_IS_HOST.getMessage());
+        }
+
+        @Test
+        @DisplayName("참여자가 아니면 참여 취소를 할 수 없다")
+        void failureByAnonymousMember() {
+            assertThatThrownBy(() -> participationService.cancel(study.getId(), participant.getId()))
+                    .isInstanceOf(StudyWithMeException.class)
+                    .hasMessage(StudyErrorCode.MEMBER_IS_NOT_PARTICIPANT.getMessage());
+        }
+
+        @Test
+        @DisplayName("참여 취소에 성공한다")
+        void success() {
+            // given
+            study.applyParticipation(participant);
+            study.approveParticipation(participant);
+
+            // when
+            participationService.cancel(study.getId(), participant.getId());
+
+            // then
+            Study findStudy = studyRepository.findById(study.getId()).orElseThrow();
+            assertAll(
+                    () -> assertThat(findStudy.getParticipants().size()).isEqualTo(2),
+                    () -> assertThat(findStudy.getParticipants()).containsExactly(host, participant),
+                    () -> assertThat(findStudy.getApproveParticipants().size()).isEqualTo(1),
+                    () -> assertThat(findStudy.getApproveParticipants()).containsExactly(host)
+            );
+        }
+    }
 }


### PR DESCRIPTION
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [X] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 정상적으로 프로그램이 동작하나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 스터디 참여 신청 API <code>/api/studies/{studyId}/applicants</code>
- 스터디 참여 승인 API <code>/api/studies/{studyId}/applicants/{applierId}/approve</code>
- 스터디 참여 거절 API <code>/api/studies/{studyId}/applicants/{applierId}/reject</code>
- 스터디 참여 취소 API <code>/api/studies/{studyId}/participants/cancel</code>
- 스터디 팀장 권한 위임 API <code>/api/studies/{studyId}/participants/{participantId}/delegation</code>

Closes #39
