### PR TITLE
[feat] 스터디 참여 승인/거부 및 졸업 시 해당 사용자에게 메일을 발송한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
 	// Spring Web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+	// Mail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	// Amazon S3 (NCP Object Storage)
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.450'

--- a/src/docs/asciidoc/study-participation.adoc
+++ b/src/docs/asciidoc/study-participation.adoc
@@ -136,6 +136,7 @@ include::{snippets}/StudyApi/Participation/Approve/Success/http-response.adoc[]
 HTTP Request
 include::{snippets}/StudyApi/Participation/Reject/Failure/Case1/http-request.adoc[]
 include::{snippets}/StudyApi/Participation/Reject/Failure/Case1/path-parameters.adoc[]
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case1/request-fields.adoc[]
 
 HTTP Response
 include::{snippets}/StudyApi/Participation/Reject/Failure/Case1/response-body.adoc[]
@@ -145,33 +146,47 @@ HTTP Request
 include::{snippets}/StudyApi/Participation/Reject/Failure/Case2/http-request.adoc[]
 include::{snippets}/StudyApi/Participation/Reject/Failure/Case2/request-headers.adoc[]
 include::{snippets}/StudyApi/Participation/Reject/Failure/Case2/path-parameters.adoc[]
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case2/request-fields.adoc[]
 
 HTTP Response
 include::{snippets}/StudyApi/Participation/Reject/Failure/Case2/response-body.adoc[]
 
-=== 3. 스터디가 종료되었다면 더이상 참여 거절을 할 수 없다
+=== 3. 거절 사유를 적지 않으면 참여 신청을 거절할 수 없다
 HTTP Request
 include::{snippets}/StudyApi/Participation/Reject/Failure/Case3/http-request.adoc[]
 include::{snippets}/StudyApi/Participation/Reject/Failure/Case3/request-headers.adoc[]
 include::{snippets}/StudyApi/Participation/Reject/Failure/Case3/path-parameters.adoc[]
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case3/request-fields.adoc[]
 
 HTTP Response
 include::{snippets}/StudyApi/Participation/Reject/Failure/Case3/response-body.adoc[]
 
-=== 4. 참여 신청자가 아니면 참여 거절을 할 수 없다
+=== 4. 스터디가 종료되었다면 더이상 참여 거절을 할 수 없다
 HTTP Request
 include::{snippets}/StudyApi/Participation/Reject/Failure/Case4/http-request.adoc[]
 include::{snippets}/StudyApi/Participation/Reject/Failure/Case4/request-headers.adoc[]
 include::{snippets}/StudyApi/Participation/Reject/Failure/Case4/path-parameters.adoc[]
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case4/request-fields.adoc[]
 
 HTTP Response
 include::{snippets}/StudyApi/Participation/Reject/Failure/Case4/response-body.adoc[]
 
-=== 5. 참여 거절을 성공한다
+=== 5. 참여 신청자가 아니면 참여 거절을 할 수 없다
+HTTP Request
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case5/http-request.adoc[]
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case5/request-headers.adoc[]
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case5/path-parameters.adoc[]
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case5/request-fields.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Participation/Reject/Failure/Case5/response-body.adoc[]
+
+=== 6. 참여 거절을 성공한다
 HTTP Request
 include::{snippets}/StudyApi/Participation/Reject/Success/http-request.adoc[]
 include::{snippets}/StudyApi/Participation/Reject/Success/request-headers.adoc[]
 include::{snippets}/StudyApi/Participation/Reject/Success/path-parameters.adoc[]
+include::{snippets}/StudyApi/Participation/Reject/Success/request-fields.adoc[]
 
 HTTP Response
 include::{snippets}/StudyApi/Participation/Reject/Success/http-response.adoc[]

--- a/src/main/java/com/kgu/studywithme/global/config/AsyncConfiguration.java
+++ b/src/main/java/com/kgu/studywithme/global/config/AsyncConfiguration.java
@@ -1,8 +1,7 @@
 package com.kgu.studywithme.global.config;
 
-import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
@@ -10,13 +9,13 @@ import java.util.concurrent.Executor;
 
 @Configuration
 @EnableAsync
-public class AsyncConfiguration implements AsyncConfigurer {
+public class AsyncConfiguration {
     private static final int CORE_POOL_SIZE = 10;
     private static final int MAX_POOL_SIZE = 25;
     private static final int QUEUE_CAPACITY = 10;
     private static final String THREAD_NAME_PREFIX = "Asynchronous Mail Sender Thread-";
 
-    @Override
+    @Bean(name = "asyncExecutor")
     public Executor getAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(CORE_POOL_SIZE);
@@ -25,10 +24,5 @@ public class AsyncConfiguration implements AsyncConfigurer {
         executor.setThreadNamePrefix(THREAD_NAME_PREFIX);
         executor.initialize();
         return executor;
-    }
-
-    @Override
-    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
-        return AsyncConfigurer.super.getAsyncUncaughtExceptionHandler();
     }
 }

--- a/src/main/java/com/kgu/studywithme/global/config/AsyncConfiguration.java
+++ b/src/main/java/com/kgu/studywithme/global/config/AsyncConfiguration.java
@@ -1,0 +1,34 @@
+package com.kgu.studywithme.global.config;
+
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfiguration implements AsyncConfigurer {
+    private static final int CORE_POOL_SIZE = 10;
+    private static final int MAX_POOL_SIZE = 25;
+    private static final int QUEUE_CAPACITY = 10;
+    private static final String THREAD_NAME_PREFIX = "Asynchronous Mail Sender Thread-";
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(CORE_POOL_SIZE);
+        executor.setMaxPoolSize(MAX_POOL_SIZE);
+        executor.setQueueCapacity(QUEUE_CAPACITY);
+        executor.setThreadNamePrefix(THREAD_NAME_PREFIX);
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return AsyncConfigurer.super.getAsyncUncaughtExceptionHandler();
+    }
+}

--- a/src/main/java/com/kgu/studywithme/global/exception/ApiGlobalExceptionHandler.java
+++ b/src/main/java/com/kgu/studywithme/global/exception/ApiGlobalExceptionHandler.java
@@ -130,7 +130,7 @@ public class ApiGlobalExceptionHandler {
      * 내부 서버 오류 전용 ExceptionHandler (With Slack Logging)
      */
     @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<ErrorResponse> handleAnyException(Exception e, HttpServletRequest request) {
+    public ResponseEntity<ErrorResponse> handleAnyException(RuntimeException e, HttpServletRequest request) {
         sendSlackAlertErrorLog(e, request);
         return convert(GlobalErrorCode.INTERNAL_SERVER_ERROR);
     }

--- a/src/main/java/com/kgu/studywithme/global/mail/event/StudyParticipationEventListener.java
+++ b/src/main/java/com/kgu/studywithme/global/mail/event/StudyParticipationEventListener.java
@@ -1,0 +1,39 @@
+package com.kgu.studywithme.global.mail.event;
+
+import com.kgu.studywithme.global.mail.utils.EmailSender;
+import com.kgu.studywithme.study.event.StudyApprovedEvent;
+import com.kgu.studywithme.study.event.StudyGraduatedEvent;
+import com.kgu.studywithme.study.event.StudyRejectedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class StudyParticipationEventListener {
+    private final EmailSender emailSender;
+
+    @Async("asyncExecutor")
+    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendParticipationApproveMail(StudyApprovedEvent event) throws Exception {
+        emailSender.sendParticipationApproveMail(event.email(), event.nickname(), event.studyName());
+    }
+
+    @Async("asyncExecutor")
+    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendParticipationRejectMail(StudyRejectedEvent event) throws Exception {
+        emailSender.sendParticipationRejectMail(event.email(), event.nickname(), event.studyName(), event.reason());
+    }
+
+    @Async("asyncExecutor")
+    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendStudyCertificateMail(StudyGraduatedEvent event) throws Exception {
+        emailSender.sendStudyCertificateMail(event.email(), event.nickname(), event.studyName());
+    }
+}

--- a/src/main/java/com/kgu/studywithme/global/mail/utils/EmailMetadata.java
+++ b/src/main/java/com/kgu/studywithme/global/mail/utils/EmailMetadata.java
@@ -1,5 +1,6 @@
 package com.kgu.studywithme.global.mail.utils;
 
 public interface EmailMetadata {
-    String EMAIL_SUBJECT = "스터디 참여 신청 결과 안내드립니다.";
+    String PARTICIPATION_SUBJECT = "스터디 참여 신청 결과 안내드립니다.";
+    String COMPLETION_SUBJECT = "스터디 수료증 관련 안내드립니다.";
 }

--- a/src/main/java/com/kgu/studywithme/global/mail/utils/EmailMetadata.java
+++ b/src/main/java/com/kgu/studywithme/global/mail/utils/EmailMetadata.java
@@ -1,0 +1,5 @@
+package com.kgu.studywithme.global.mail.utils;
+
+public interface EmailMetadata {
+    String EMAIL_SUBJECT = "스터디 참여 신청 결과 안내드립니다.";
+}

--- a/src/main/java/com/kgu/studywithme/global/mail/utils/EmailSender.java
+++ b/src/main/java/com/kgu/studywithme/global/mail/utils/EmailSender.java
@@ -1,0 +1,54 @@
+package com.kgu.studywithme.global.mail.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring5.SpringTemplateEngine;
+
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+import static com.kgu.studywithme.global.mail.utils.EmailMetadata.EMAIL_SUBJECT;
+
+@Component
+@RequiredArgsConstructor
+public class EmailSender {
+    private final JavaMailSender mailSender;
+    private final SpringTemplateEngine templateEngine;
+
+    @Value("${spring.mail.username}")
+    private String serviceEmail;
+    private static final String APPROVE_TEMPLATE = "ParticipationApproveEmailTemplate";
+    private static final String REJECT_TEMPLATE = "ParticipationRejectEmailTemplate";
+
+    public void sendParticipationApproveMail(String applierEmail, String nickname, String studyName) throws Exception {
+        Context context = new Context();
+        context.setVariable("nickname", nickname);
+        context.setVariable("studyName", studyName);
+
+        String mailBody = templateEngine.process(APPROVE_TEMPLATE, context);
+        sendMail(applierEmail, mailBody);
+    }
+
+    public void sendParticipationRejectMail(String applierEmail, String nickname, String studyName, String reason) throws Exception {
+        Context context = new Context();
+        context.setVariable("nickname", nickname);
+        context.setVariable("studyName", studyName);
+        context.setVariable("reason", reason);
+
+        String mailBody = templateEngine.process(REJECT_TEMPLATE, context);
+        sendMail(applierEmail, mailBody);
+    }
+
+    private void sendMail(String applierEmail, String mailBody) throws Exception {
+        MimeMessage message = mailSender.createMimeMessage();
+        message.addRecipients(MimeMessage.RecipientType.TO, applierEmail);
+        message.setSubject(EMAIL_SUBJECT);
+        message.setText(mailBody, "UTF-8", "HTML");
+        message.setFrom(new InternetAddress(serviceEmail, "여기서 구해볼래?"));
+
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/kgu/studywithme/global/mail/utils/EmailSender.java
+++ b/src/main/java/com/kgu/studywithme/global/mail/utils/EmailSender.java
@@ -9,8 +9,11 @@ import org.thymeleaf.spring5.SpringTemplateEngine;
 
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
-import static com.kgu.studywithme.global.mail.utils.EmailMetadata.EMAIL_SUBJECT;
+import static com.kgu.studywithme.global.mail.utils.EmailMetadata.COMPLETION_SUBJECT;
+import static com.kgu.studywithme.global.mail.utils.EmailMetadata.PARTICIPATION_SUBJECT;
 
 @Component
 @RequiredArgsConstructor
@@ -22,6 +25,8 @@ public class EmailSender {
     private String serviceEmail;
     private static final String APPROVE_TEMPLATE = "ParticipationApproveEmailTemplate";
     private static final String REJECT_TEMPLATE = "ParticipationRejectEmailTemplate";
+    private static final String CERTIFICATE_TEMPLATE = "StudyCertificateEmailTemplate";
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일");
 
     public void sendParticipationApproveMail(String applierEmail, String nickname, String studyName) throws Exception {
         Context context = new Context();
@@ -29,7 +34,7 @@ public class EmailSender {
         context.setVariable("studyName", studyName);
 
         String mailBody = templateEngine.process(APPROVE_TEMPLATE, context);
-        sendMail(applierEmail, mailBody);
+        sendMail(PARTICIPATION_SUBJECT, applierEmail, mailBody);
     }
 
     public void sendParticipationRejectMail(String applierEmail, String nickname, String studyName, String reason) throws Exception {
@@ -39,13 +44,23 @@ public class EmailSender {
         context.setVariable("reason", reason);
 
         String mailBody = templateEngine.process(REJECT_TEMPLATE, context);
-        sendMail(applierEmail, mailBody);
+        sendMail(PARTICIPATION_SUBJECT, applierEmail, mailBody);
     }
 
-    private void sendMail(String applierEmail, String mailBody) throws Exception {
+    public void sendStudyCertificateMail(String applierEmail, String nickname, String studyName) throws Exception {
+        Context context = new Context();
+        context.setVariable("nickname", nickname);
+        context.setVariable("studyName", studyName);
+        context.setVariable("completionDate", LocalDate.now().format(DATE_TIME_FORMATTER));
+
+        String mailBody = templateEngine.process(CERTIFICATE_TEMPLATE, context);
+        sendMail(COMPLETION_SUBJECT, applierEmail, mailBody);
+    }
+
+    private void sendMail(String subjectType, String applierEmail, String mailBody) throws Exception {
         MimeMessage message = mailSender.createMimeMessage();
         message.addRecipients(MimeMessage.RecipientType.TO, applierEmail);
-        message.setSubject(EMAIL_SUBJECT);
+        message.setSubject(subjectType);
         message.setText(mailBody, "UTF-8", "HTML");
         message.setFrom(new InternetAddress(serviceEmail, "여기서 구해볼래?"));
 

--- a/src/main/java/com/kgu/studywithme/study/controller/StudyParticipationApiController.java
+++ b/src/main/java/com/kgu/studywithme/study/controller/StudyParticipationApiController.java
@@ -3,10 +3,13 @@ package com.kgu.studywithme.study.controller;
 import com.kgu.studywithme.global.annotation.CheckStudyHost;
 import com.kgu.studywithme.global.annotation.CheckStudyParticipant;
 import com.kgu.studywithme.global.annotation.ExtractPayload;
+import com.kgu.studywithme.study.controller.dto.request.ParticipationRejectRequest;
 import com.kgu.studywithme.study.service.ParticipationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
@@ -39,8 +42,9 @@ public class StudyParticipationApiController {
     @PatchMapping("/applicants/{applierId}/reject")
     public ResponseEntity<Void> reject(@ExtractPayload Long hostId,
                                        @PathVariable Long studyId,
-                                       @PathVariable Long applierId) {
-        participationService.reject(studyId, applierId, hostId);
+                                       @PathVariable Long applierId,
+                                       @RequestBody @Valid ParticipationRejectRequest request) {
+        participationService.reject(studyId, applierId, hostId, request.reason());
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/kgu/studywithme/study/controller/dto/request/ParticipationRejectRequest.java
+++ b/src/main/java/com/kgu/studywithme/study/controller/dto/request/ParticipationRejectRequest.java
@@ -1,0 +1,9 @@
+package com.kgu.studywithme.study.controller.dto.request;
+
+import javax.validation.constraints.NotBlank;
+
+public record ParticipationRejectRequest(
+        @NotBlank(message = "참여 거절 사유는 필수입니다.")
+        String reason
+) {
+}

--- a/src/main/java/com/kgu/studywithme/study/event/StudyApprovedEvent.java
+++ b/src/main/java/com/kgu/studywithme/study/event/StudyApprovedEvent.java
@@ -1,0 +1,8 @@
+package com.kgu.studywithme.study.event;
+
+public record StudyApprovedEvent(
+        String email,
+        String nickname,
+        String studyName
+) {
+}

--- a/src/main/java/com/kgu/studywithme/study/event/StudyGraduatedEvent.java
+++ b/src/main/java/com/kgu/studywithme/study/event/StudyGraduatedEvent.java
@@ -1,0 +1,8 @@
+package com.kgu.studywithme.study.event;
+
+public record StudyGraduatedEvent(
+        String email,
+        String nickname,
+        String studyName
+) {
+}

--- a/src/main/java/com/kgu/studywithme/study/event/StudyRejectedEvent.java
+++ b/src/main/java/com/kgu/studywithme/study/event/StudyRejectedEvent.java
@@ -1,0 +1,9 @@
+package com.kgu.studywithme.study.event;
+
+public record StudyRejectedEvent(
+        String email,
+        String nickname,
+        String studyName,
+        String reason
+) {
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -3,6 +3,29 @@ spring:
     import:
       - application-logging.yml
 
+  thymeleaf:
+    cache: false
+
+  mail:
+    default-encoding: UTF-8
+    host: smtp.naver.com
+    port: 465
+    username: username
+    password: password
+    properties:
+      mail:
+        mime:
+          charset: UTF-8
+        transport:
+          protocol: smtp
+        debug: true
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+          ssl:
+            enable: true
+
   datasource:
     url: jdbc:h2:mem:test;MODE=MYSQL;
     username: sa

--- a/src/main/resources/templates/ParticipationApproveEmailTemplate.html
+++ b/src/main/resources/templates/ParticipationApproveEmailTemplate.html
@@ -31,8 +31,8 @@
 </head>
 <body>
 <div class="container">
-    <h1><strong th:text="${studyName}">asdasd</strong> 참여 승인 메일</h1>
-    <p>축하드립니다! <strong th:text="${nickname}">asdasd</strong>님은 <strong th:text="${studyName}">asdas</strong>에 참여하게 되셨습니다.</p>
+    <h1><strong th:text="${studyName}"></strong> 참여 승인 메일</h1>
+    <p>축하드립니다! <strong th:text="${nickname}"></strong>님은 <strong th:text="${studyName}"></strong>에 참여하게 되셨습니다.</p>
     <p>이 스터디에서 많은 도움과 지식을 얻으실 수 있기를 바랍니다.</p>
     <p>스터디 관련 자세한 정보는 저희 사이트를 참고해주세요.</p>
     <p>감사합니다.</p>

--- a/src/main/resources/templates/ParticipationApproveEmailTemplate.html
+++ b/src/main/resources/templates/ParticipationApproveEmailTemplate.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>여기서 구해볼래?</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 30px;
+            text-align: left;
+        }
+
+        .container {
+            padding: 20px;
+            max-width: 600px;
+            margin: 0 auto;
+        }
+
+        h1 {
+            font-size: 24px;
+            color: #333;
+            margin-bottom: 10px;
+        }
+
+        p {
+            font-size: 16px;
+            color: #555;
+            line-height: 1.5;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1><strong th:text="${studyName}">asdasd</strong> 참여 승인 메일</h1>
+    <p>축하드립니다! <strong th:text="${nickname}">asdasd</strong>님은 <strong th:text="${studyName}">asdas</strong>에 참여하게 되셨습니다.</p>
+    <p>이 스터디에서 많은 도움과 지식을 얻으실 수 있기를 바랍니다.</p>
+    <p>스터디 관련 자세한 정보는 저희 사이트를 참고해주세요.</p>
+    <p>감사합니다.</p>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/ParticipationRejectEmailTemplate.html
+++ b/src/main/resources/templates/ParticipationRejectEmailTemplate.html
@@ -39,13 +39,13 @@
 </head>
 <body>
 <div class="container">
-    <h1><strong th:text="${studyName}">asdasd</strong> 참여 거절 메일</h1>
-    <p>아쉽게도 <strong th:text="${nickname}">asdasd</strong>님은 <strong th:text="${studyName}">asdas</strong>에 참여하실 수 없게 되었습니다.</p>
+    <h1><strong th:text="${studyName}"></strong> 참여 거절 메일</h1>
+    <p>아쉽게도 <strong th:text="${nickname}"></strong>님은 <strong th:text="${studyName}"></strong>에 참여하실 수 없게 되었습니다.</p>
     <p>스터디 참여는 선착순이 아닌 스터디 팀장이 신청자의 정보를 기준으로 승인 여부를 결정하게 되어 있습니다.</p>
     <p>다른 스터디를 찾아보시거나, 다음 기회에 다시 신청해주시길 바랍니다.</p>
     <p>감사합니다.</p>
     <div class="rejection-reason">
-        <p><strong th:text="|거절 사유: ${reason}|">ㅁㄴㅇ런밍러민어리ㅏㄴㅁㅇ</strong></p>
+        <p><strong th:text="|거절 사유: ${reason}|"></strong></p>
     </div>
 </div>
 </body>

--- a/src/main/resources/templates/ParticipationRejectEmailTemplate.html
+++ b/src/main/resources/templates/ParticipationRejectEmailTemplate.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>여기서 구해볼래?</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 30px;
+            text-align: left;
+        }
+
+        .container {
+            padding: 20px;
+            max-width: 600px;
+            margin: 0 auto;
+        }
+
+        h1 {
+            font-size: 24px;
+            color: #333;
+            margin-bottom: 10px;
+        }
+
+        p {
+            font-size: 16px;
+            color: #555;
+            line-height: 1.5;
+        }
+
+        .rejection-reason {
+            border: 2px solid #ff6b81;
+            border-radius: 5px;
+            padding: 10px;
+            background-color: #ffe4e6;
+            display: inline-block;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1><strong th:text="${studyName}">asdasd</strong> 참여 거절 메일</h1>
+    <p>아쉽게도 <strong th:text="${nickname}">asdasd</strong>님은 <strong th:text="${studyName}">asdas</strong>에 참여하실 수 없게 되었습니다.</p>
+    <p>스터디 참여는 선착순이 아닌 스터디 팀장이 신청자의 정보를 기준으로 승인 여부를 결정하게 되어 있습니다.</p>
+    <p>다른 스터디를 찾아보시거나, 다음 기회에 다시 신청해주시길 바랍니다.</p>
+    <p>감사합니다.</p>
+    <div class="rejection-reason">
+        <p><strong th:text="|거절 사유: ${reason}|">ㅁㄴㅇ런밍러민어리ㅏㄴㅁㅇ</strong></p>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/StudyCertificateEmailTemplate.html
+++ b/src/main/resources/templates/StudyCertificateEmailTemplate.html
@@ -52,14 +52,14 @@
     <h2>스터디 수료인증서</h2>
     <p>
         <span>NAME</span><br>
-        <strong th:text="${nickname}" style="font-size: 30px;">닉네임</strong>
+        <strong th:text="${nickname}" style="font-size: 30px;"></strong>
     </p>
     <p>
         <span>STUDY</span><br>
-        <strong th:text="${studyName}" style="font-size: 30px;">스터디 이름</strong>
+        <strong th:text="${studyName}" style="font-size: 30px;"></strong>
     </p>
     <p>위의 스터디를 성공적으로 수료하였음을 인정하여 이 수료증을 수여합니다.</p>
-    <p class="completion-date" th:text="|수료일: ${completionDate}|">수료 날짜: yyyy년 MM월 dd일</p>
+    <p class="completion-date" th:text="|수료일: ${completionDate}|"></p>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/StudyCertificateEmailTemplate.html
+++ b/src/main/resources/templates/StudyCertificateEmailTemplate.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>여기서 구해볼래? - 수료증</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 30px;
+            margin: 0;
+        }
+
+        .container {
+            padding: 20px;
+            max-width: 600px;
+            margin: 0 auto;
+        }
+
+        h1 {
+            font-size: 24px;
+            color: #333;
+            margin-bottom: 10px;
+            text-align: center;
+        }
+
+        h2 {
+            font-size: 18px;
+            color: #555;
+            margin-bottom: 5px;
+            text-align: center;
+        }
+
+        p {
+            font-size: 16px;
+            color: #555;
+            line-height: 1.5;
+            text-align: center;
+        }
+
+        .completion-date {
+            font-size: 18px;
+            font-weight: bold;
+            color: #333;
+            text-align: center;
+            margin-top: 10px;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>CERTIFICATE OF COMPLETION</h1>
+    <h2>스터디 수료인증서</h2>
+    <p>
+        <span>NAME</span><br>
+        <strong th:text="${nickname}" style="font-size: 30px;">닉네임</strong>
+    </p>
+    <p>
+        <span>STUDY</span><br>
+        <strong th:text="${studyName}" style="font-size: 30px;">스터디 이름</strong>
+    </p>
+    <p>위의 스터디를 성공적으로 수료하였음을 인정하여 이 수료증을 수여합니다.</p>
+    <p class="completion-date" th:text="|수료일: ${completionDate}|">수료 날짜: yyyy년 MM월 dd일</p>
+</div>
+</body>
+</html>

--- a/src/test/java/com/kgu/studywithme/study/service/ParticipationServiceTest.java
+++ b/src/test/java/com/kgu/studywithme/study/service/ParticipationServiceTest.java
@@ -204,6 +204,7 @@ class ParticipationServiceTest extends ServiceTest {
         private Member host;
         private Member applier;
         private Study study;
+        private static final String REASON = "나이가 너무 많아요";
 
         @BeforeEach
         void setUp() {
@@ -219,7 +220,7 @@ class ParticipationServiceTest extends ServiceTest {
             study.close();
 
             // when - then
-            assertThatThrownBy(() -> participationService.reject(study.getId(), applier.getId(), host.getId()))
+            assertThatThrownBy(() -> participationService.reject(study.getId(), applier.getId(), host.getId(), REASON))
                     .isInstanceOf(StudyWithMeException.class)
                     .hasMessage(StudyErrorCode.ALREADY_CLOSED.getMessage());
         }
@@ -227,7 +228,7 @@ class ParticipationServiceTest extends ServiceTest {
         @Test
         @DisplayName("참여 신청자가 아니면 참여 거절을 할 수 없다")
         void throwExceptionByMemberIsNotApplier() {
-            assertThatThrownBy(() -> participationService.reject(study.getId(), applier.getId(), host.getId()))
+            assertThatThrownBy(() -> participationService.reject(study.getId(), applier.getId(), host.getId(), REASON))
                     .isInstanceOf(StudyWithMeException.class)
                     .hasMessage(StudyErrorCode.MEMBER_IS_NOT_APPLIER.getMessage());
         }
@@ -239,7 +240,7 @@ class ParticipationServiceTest extends ServiceTest {
             study.applyParticipation(applier);
 
             // when
-            participationService.reject(study.getId(), applier.getId(), host.getId());
+            participationService.reject(study.getId(), applier.getId(), host.getId(), REASON);
 
             // then
             Study findStudy = studyRepository.findById(study.getId()).orElseThrow();

--- a/src/test/java/com/kgu/studywithme/study/service/ParticipationServiceTest.java
+++ b/src/test/java/com/kgu/studywithme/study/service/ParticipationServiceTest.java
@@ -4,12 +4,17 @@ import com.kgu.studywithme.common.ServiceTest;
 import com.kgu.studywithme.global.exception.StudyWithMeException;
 import com.kgu.studywithme.member.domain.Member;
 import com.kgu.studywithme.study.domain.Study;
+import com.kgu.studywithme.study.event.StudyApprovedEvent;
+import com.kgu.studywithme.study.event.StudyGraduatedEvent;
+import com.kgu.studywithme.study.event.StudyRejectedEvent;
 import com.kgu.studywithme.study.exception.StudyErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static com.kgu.studywithme.fixture.MemberFixture.GHOST;
@@ -19,10 +24,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+@RecordApplicationEvents
 @DisplayName("Study [Service Layer] -> ParticipationService 테스트")
 class ParticipationServiceTest extends ServiceTest {
     @Autowired
     private ParticipationService participationService;
+
+    @Autowired
+    private ApplicationEvents events;
 
     @Nested
     @DisplayName("스터디 참여 신청")
@@ -195,6 +204,9 @@ class ParticipationServiceTest extends ServiceTest {
                     () -> assertThat(findStudy.getApproveParticipants()).hasSize(2),
                     () -> assertThat(findStudy.getApproveParticipants()).containsExactlyInAnyOrder(host, applier)
             );
+
+            int count = (int) events.stream(StudyApprovedEvent.class).count();
+            assertThat(count).isEqualTo(1);
         }
     }
 
@@ -250,6 +262,9 @@ class ParticipationServiceTest extends ServiceTest {
                     () -> assertThat(findStudy.getApproveParticipants()).hasSize(1),
                     () -> assertThat(findStudy.getApproveParticipants()).containsExactlyInAnyOrder(host)
             );
+
+            int count = (int) events.stream(StudyRejectedEvent.class).count();
+            assertThat(count).isEqualTo(1);
         }
     }
 
@@ -382,6 +397,9 @@ class ParticipationServiceTest extends ServiceTest {
                     () -> assertThat(findStudy.getGraduatedParticipants()).hasSize(1),
                     () -> assertThat(findStudy.getGraduatedParticipants()).containsExactlyInAnyOrder(participant)
             );
+
+            int count = (int) events.stream(StudyGraduatedEvent.class).count();
+            assertThat(count).isEqualTo(1);
         }
     }
 


### PR DESCRIPTION
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [X] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 정상적으로 프로그램이 동작하나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 스터디 참여 승인/거부 및 졸업 시 해당 사용자에게 메일을 발송하는 로직 구현
- 비동기 메일 발송 호출에 대한 테스트 코드 추가

Closes #150
