### PR TITLE
[feat] 제출한 과제에 대한 수정 API를 구현한다

### DIFF
--- a/src/docs/asciidoc/study-weekly.adoc
+++ b/src/docs/asciidoc/study-weekly.adoc
@@ -103,3 +103,58 @@ include::{snippets}/StudyApi/Weekly/SubmitAssignment/Success/Case2/request-param
 
 HTTP Response
 include::{snippets}/StudyApi/Weekly/SubmitAssignment/Success/Case2/http-response.adoc[]
+
+== 스터디 주차별 제출한 과제 수정
+=== 1. Authorization Header에 AccessToken이 없으면 제출한 과제를 수정할 수 없다
+HTTP Request
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case1/http-request.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case1/path-parameters.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case1/request-parts.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case1/request-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case1/response-body.adoc[]
+
+=== 2. 스터디 참여자가 아니라면 제출한 과제를 수정할 수 없다
+HTTP Request
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case2/http-request.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case2/request-headers.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case2/path-parameters.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case2/request-parts.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case2/request-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case2/response-body.adoc[]
+
+=== 3. 과제 제출물을 업로드 하지 않으면 예외가 발생한다
+HTTP Request
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case3/http-request.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case3/request-headers.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case3/path-parameters.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case3/request-parts.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case3/request-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case3/response-body.adoc[]
+
+=== 4. 링크 + 파일을 둘다 업로드하면 예외가 발생한다
+HTTP Request
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case4/http-request.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case4/request-headers.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case4/path-parameters.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case4/request-parts.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case4/request-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Failure/Case4/response-body.adoc[]
+
+=== 5. 제출한 과제를 수정한다
+HTTP Request
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Success/http-request.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Success/request-headers.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Success/path-parameters.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Success/request-parts.adoc[]
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Success/request-parameters.adoc[]
+
+HTTP Response
+include::{snippets}/StudyApi/Weekly/EditSubmittedAssignment/Success/http-response.adoc[]

--- a/src/main/java/com/kgu/studywithme/global/annotation/validation/ValidUploadType.java
+++ b/src/main/java/com/kgu/studywithme/global/annotation/validation/ValidUploadType.java
@@ -1,0 +1,17 @@
+package com.kgu.studywithme.global.annotation.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidUploadTypeValidator.class)
+public @interface ValidUploadType {
+    String message() default "잘못된 요청입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/kgu/studywithme/global/annotation/validation/ValidUploadTypeValidator.java
+++ b/src/main/java/com/kgu/studywithme/global/annotation/validation/ValidUploadTypeValidator.java
@@ -1,0 +1,14 @@
+package com.kgu.studywithme.global.annotation.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.List;
+
+public class ValidUploadTypeValidator implements ConstraintValidator<ValidUploadType, String> {
+    private static final List<String> ALLOWED_TYPE = List.of("link", "file");
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return ALLOWED_TYPE.contains(value);
+    }
+}

--- a/src/main/java/com/kgu/studywithme/study/controller/dto/request/WeeklyAssignmentSubmitRequest.java
+++ b/src/main/java/com/kgu/studywithme/study/controller/dto/request/WeeklyAssignmentSubmitRequest.java
@@ -1,10 +1,12 @@
 package com.kgu.studywithme.study.controller.dto.request;
 
+import com.kgu.studywithme.global.annotation.validation.ValidUploadType;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotBlank;
 
 public record WeeklyAssignmentSubmitRequest(
+        @ValidUploadType
         @NotBlank(message = "과제 제출 타입은 필수입니다.")
         String type,
         MultipartFile file,

--- a/src/main/java/com/kgu/studywithme/study/controller/week/StudyWeeklyApiController.java
+++ b/src/main/java/com/kgu/studywithme/study/controller/week/StudyWeeklyApiController.java
@@ -39,4 +39,14 @@ public class StudyWeeklyApiController {
         studyWeeklyService.submitAssignment(memberId, studyId, week, request.type(), request.file(), request.link());
         return ResponseEntity.noContent().build();
     }
+
+    @CheckStudyParticipant
+    @PostMapping(value = "/assignment/edit", consumes = MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Void> editSubmittedAssignment(@ExtractPayload Long memberId,
+                                                        @PathVariable Long studyId,
+                                                        @PathVariable Integer week,
+                                                        @ModelAttribute @Valid WeeklyAssignmentSubmitRequest request) {
+        studyWeeklyService.editSubmittedAssignment(memberId, week, request.type(), request.file(), request.link());
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/kgu/studywithme/study/domain/week/submit/Submit.java
+++ b/src/main/java/com/kgu/studywithme/study/domain/week/submit/Submit.java
@@ -38,4 +38,8 @@ public class Submit extends BaseEntity {
     public static Submit submitAssignment(Week week, Member participant, Upload upload) {
         return new Submit(week, participant, upload);
     }
+
+    public void editUpload(Upload upload) {
+        this.upload = upload;
+    }
 }

--- a/src/main/java/com/kgu/studywithme/study/domain/week/submit/SubmitRepository.java
+++ b/src/main/java/com/kgu/studywithme/study/domain/week/submit/SubmitRepository.java
@@ -1,6 +1,16 @@
 package com.kgu.studywithme.study.domain.week.submit;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface SubmitRepository extends JpaRepository<Submit, Long> {
+    @Query("SELECT s" +
+            " FROM Submit s" +
+            " INNER JOIN s.week w" +
+            " WHERE s.participant.id = :participantId AND w.week = :week")
+    Optional<Submit> findByParticipantIdAndWeek(@Param("participantId") Long participantId,
+                                                @Param("week") Integer week);
 }

--- a/src/main/java/com/kgu/studywithme/study/exception/StudyErrorCode.java
+++ b/src/main/java/com/kgu/studywithme/study/exception/StudyErrorCode.java
@@ -41,6 +41,7 @@ public enum StudyErrorCode implements ErrorCode {
     GRADUATION_REQUIREMENTS_NOT_FULFILLED(HttpStatus.CONFLICT, "STUDY_031", "졸업 요건을 채우지 못하였습니다."),
     STUDY_THUMBNAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY_032", "제공해주지 않는 썸네일입니다."),
     CANNOT_UPDATE_TO_NON_ATTENDANCE(HttpStatus.CONFLICT, "STUDY_033", "미출결 상태로 출석을 수정할 수 없습니다."),
+    SUBMIT_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY_034", "제출한 과제가 존재하지 않습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/test/java/com/kgu/studywithme/global/annotation/validation/ValidStudyTypeValidatorTest.java
+++ b/src/test/java/com/kgu/studywithme/global/annotation/validation/ValidStudyTypeValidatorTest.java
@@ -23,7 +23,7 @@ class ValidStudyTypeValidatorTest {
 
     @Test
     @DisplayName("허용하지 않는 스터디 타입이 들어오면 validator를 통과하지 못한다")
-    void notAllowedGender() {
+    void notAllowedStudyType() {
         // given
         final String unknown = "unknown";
 
@@ -36,7 +36,7 @@ class ValidStudyTypeValidatorTest {
 
     @Test
     @DisplayName("허용하는 스터디 타입이 들어오면 validator를 통과한다")
-    void allowedGender() {
+    void allowedStudyType() {
         // given
         final String on1 = "on";
         final String on2 = "ON";

--- a/src/test/java/com/kgu/studywithme/global/annotation/validation/ValidUploadTypeValidatorTest.java
+++ b/src/test/java/com/kgu/studywithme/global/annotation/validation/ValidUploadTypeValidatorTest.java
@@ -1,0 +1,54 @@
+package com.kgu.studywithme.global.annotation.validation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintValidatorContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("Annotation ConstraintValidator -> ValidUploadTypeValidator 테스트")
+class ValidUploadTypeValidatorTest {
+    private ValidUploadTypeValidator validator;
+    private ConstraintValidatorContext context;
+
+    @BeforeEach
+    void setUp() {
+        validator = new ValidUploadTypeValidator();
+        context = mock(ConstraintValidatorContext.class);
+    }
+
+    @Test
+    @DisplayName("허용하지 않는 업로드 타입이 들어오면 validator를 통과하지 못한다")
+    void notAllowedUploadType() {
+        // given
+        final String unknown = "unknown";
+
+        // when
+        boolean actual = validator.isValid(unknown, context);
+
+        // then
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    @DisplayName("허용하는 업로드 타입이 들어오면 validator를 통과한다")
+    void allowedUploadType() {
+        // given
+        final String link = "link";
+        final String file = "file";
+
+        // when
+        boolean actual1 = validator.isValid(link, context);
+        boolean actual2 = validator.isValid(file, context);
+
+        // then
+        assertAll(
+                () -> assertThat(actual1).isTrue(),
+                () -> assertThat(actual2).isTrue()
+        );
+    }
+}

--- a/src/test/java/com/kgu/studywithme/study/domain/week/submit/SubmitRepositoryTest.java
+++ b/src/test/java/com/kgu/studywithme/study/domain/week/submit/SubmitRepositoryTest.java
@@ -1,0 +1,73 @@
+package com.kgu.studywithme.study.domain.week.submit;
+
+import com.kgu.studywithme.common.RepositoryTest;
+import com.kgu.studywithme.member.domain.Member;
+import com.kgu.studywithme.member.domain.MemberRepository;
+import com.kgu.studywithme.study.domain.Study;
+import com.kgu.studywithme.study.domain.StudyRepository;
+import com.kgu.studywithme.study.domain.week.Week;
+import com.kgu.studywithme.study.domain.week.WeekRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+import static com.kgu.studywithme.fixture.MemberFixture.GHOST;
+import static com.kgu.studywithme.fixture.MemberFixture.JIWON;
+import static com.kgu.studywithme.fixture.StudyFixture.SPRING;
+import static com.kgu.studywithme.fixture.WeekFixture.STUDY_WEEKLY_1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("Study [Repository Layer] -> SubmitRepository 테스트")
+class SubmitRepositoryTest extends RepositoryTest {
+    @Autowired
+    private SubmitRepository submitRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private StudyRepository studyRepository;
+
+    @Autowired
+    private WeekRepository weekRepository;
+
+    private Member host;
+    private Member participant;
+    private Study study;
+    private Week week;
+
+    @BeforeEach
+    void setUp() {
+        host = memberRepository.save(JIWON.toMember());
+        participant = memberRepository.save(GHOST.toMember());
+        study = studyRepository.save(SPRING.toOnlineStudy(host));
+        week = weekRepository.save(STUDY_WEEKLY_1.toWeekWithAssignment(study));
+    }
+
+    @Test
+    @DisplayName("특정 주차에 제출한 과제를 조회한다")
+    void findByParticipantIdAndWeek() {
+        // given
+        final Upload upload = Upload.withLink("https://notion.link");
+        week.submitAssignment(host, upload);
+
+        // when
+        Optional<Submit> hostSubmit = submitRepository.findByParticipantIdAndWeek(host.getId(), STUDY_WEEKLY_1.getWeek());
+        Optional<Submit> participantSubmit = submitRepository.findByParticipantIdAndWeek(participant.getId(), STUDY_WEEKLY_1.getWeek());
+
+        // then
+        assertThat(hostSubmit).isPresent();
+        assertThat(participantSubmit).isEmpty();
+
+        Submit submit = hostSubmit.get();
+        assertAll(
+                () -> assertThat(submit.getUpload()).isEqualTo(upload),
+                () -> assertThat(submit.getWeek()).isEqualTo(week),
+                () -> assertThat(submit.getParticipant()).isEqualTo(host)
+        );
+    }
+}

--- a/src/test/java/com/kgu/studywithme/study/domain/week/submit/SubmitTest.java
+++ b/src/test/java/com/kgu/studywithme/study/domain/week/submit/SubmitTest.java
@@ -29,7 +29,6 @@ class SubmitTest {
         assertAll(
                 () -> assertThat(submit.getWeek()).isEqualTo(WEEK),
                 () -> assertThat(submit.getParticipant()).isEqualTo(HOST),
-                () -> assertThat(submit.getUpload()).isEqualTo(upload),
                 () -> assertThat(submit.getUpload().getLink()).isEqualTo("https://notion.com"),
                 () -> assertThat(submit.getUpload().getType()).isEqualTo(LINK)
         );
@@ -44,9 +43,28 @@ class SubmitTest {
         assertAll(
                 () -> assertThat(submit.getWeek()).isEqualTo(WEEK),
                 () -> assertThat(submit.getParticipant()).isEqualTo(HOST),
-                () -> assertThat(submit.getUpload()).isEqualTo(upload),
                 () -> assertThat(submit.getUpload().getLink()).isEqualTo("file_upload_link"),
                 () -> assertThat(submit.getUpload().getType()).isEqualTo(FILE)
+        );
+    }
+
+    @Test
+    @DisplayName("업로드한 과제를 수정한다")
+    void editUpload() {
+        // given
+        final Upload upload = Upload.withFile("file_upload_link");
+        Submit submit = Submit.submitAssignment(WEEK, HOST, upload);
+
+        // when
+        final Upload newUpload = Upload.withLink("https://notion.so");
+        submit.editUpload(newUpload);
+
+        // then
+        assertAll(
+                () -> assertThat(submit.getWeek()).isEqualTo(WEEK),
+                () -> assertThat(submit.getParticipant()).isEqualTo(HOST),
+                () -> assertThat(submit.getUpload().getLink()).isEqualTo(newUpload.getLink()),
+                () -> assertThat(submit.getUpload().getType()).isEqualTo(newUpload.getType())
         );
     }
 }

--- a/src/test/java/com/kgu/studywithme/study/domain/week/submit/UploadTest.java
+++ b/src/test/java/com/kgu/studywithme/study/domain/week/submit/UploadTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 @DisplayName("Study-Week-Submit 도메인 {Upload VO} 테스트")
 class UploadTest {
     @Test
-    @DisplayName("Notion, Blog 등 링크를 통해서 과제물을 제출한다")
+    @DisplayName("Notion, Blog 등 링크를 통해서 과제를 제출한다")
     void constructWithLink() {
         Upload upload = Upload.withLink("https://notion.com");
 
@@ -22,7 +22,7 @@ class UploadTest {
     }
 
     @Test
-    @DisplayName("파일 업로드를 통해서 과제물을 제출한다")
+    @DisplayName("파일 업로드를 통해서 과제를 제출한다")
     void constructWithFile() {
         Upload upload = Upload.withFile("file_upload_link");
 

--- a/src/test/java/com/kgu/studywithme/upload/utils/FileUploaderTest.java
+++ b/src/test/java/com/kgu/studywithme/upload/utils/FileUploaderTest.java
@@ -159,7 +159,7 @@ class FileUploaderTest extends InfraTest {
         }
 
         @Test
-        @DisplayName("과제물 업로드를 성공한다")
+        @DisplayName("과제 업로드를 성공한다")
         void success() throws Exception {
             // given
             MultipartFile file = createSingleMockMultipartFile("hello3.pdf", "application/pdf");


### PR DESCRIPTION
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [X] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 정상적으로 프로그램이 동작하나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 제출한 과제 수정 API 구현
- 테스트 코드

> - `multipart/form-data` MockMvc 테스트 시 `@PatchMapping`으로 시도
> - `RestDocumentationRequestBuilders.multipart`는 POST로 고정되어있기 때문에 `MockMvcRequestBuilders.multpart`를 사용하려고 했는데 URI 설계상 PathVariable이 존재하기 때문에 사용 불가
> - 따라서 URI 설계를 `POST ~~/edit`로 수정

Closes #168
