### PR TITLE
[fix] 결석 처리에 대한 스케줄링 시 결석자에 대한 Score 업데이트 누락을 추가한다

### DIFF
--- a/src/main/java/com/kgu/studywithme/member/domain/MemberRepository.java
+++ b/src/main/java/com/kgu/studywithme/member/domain/MemberRepository.java
@@ -2,10 +2,12 @@ package com.kgu.studywithme.member.domain;
 
 import com.kgu.studywithme.member.infra.query.MemberSimpleQueryRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
+import java.util.Set;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberSimpleQueryRepository {
     // @Query
@@ -14,6 +16,12 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberSim
             " JOIN FETCH m.interests" +
             " WHERE m.id = :memberId")
     Optional<Member> findByIdWithInterests(@Param("memberId") Long memberId);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("UPDATE Member m" +
+            " SET m.score = m.score.value - 5" +
+            " WHERE m.id IN :absenceParticipantIds")
+    void applyAbsenceScore(@Param("absenceParticipantIds") Set<Long> absenceParticipantIds);
 
     // Query Method
     Optional<Member> findByEmail(Email email);

--- a/src/main/java/com/kgu/studywithme/member/domain/Score.java
+++ b/src/main/java/com/kgu/studywithme/member/domain/Score.java
@@ -28,6 +28,10 @@ public class Score {
         this.value = value < MINIMUM ? MINIMUM : Math.min(value, MAXIMUM);
     }
 
+    public static Score from(int value) {
+        return new Score(value);
+    }
+
     public static Score initScore() {
         return new Score(DEFAULT_INIT_VALUE);
     }

--- a/src/main/java/com/kgu/studywithme/member/service/dto/response/MemberInformation.java
+++ b/src/main/java/com/kgu/studywithme/member/service/dto/response/MemberInformation.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public record MemberInformation(
         Long id, String name, String nickname, String email, LocalDate birth,
-        String phone, String gender, Region region, List<String> interests
+        String phone, String gender, Region region, int score, List<String> interests
 ) {
     public MemberInformation(Member member) {
         this(
@@ -21,6 +21,7 @@ public record MemberInformation(
                 member.getPhone(),
                 member.getGender().getValue(),
                 member.getRegion(),
+                member.getScore(),
                 translateInterests(member)
         );
     }

--- a/src/main/java/com/kgu/studywithme/study/infra/query/StudyInformationQueryRepositoryImpl.java
+++ b/src/main/java/com/kgu/studywithme/study/infra/query/StudyInformationQueryRepositoryImpl.java
@@ -78,7 +78,7 @@ public class StudyInformationQueryRepositoryImpl implements StudyInformationQuer
     @Override
     public List<StudyApplicantInformation> findApplicantByStudyId(Long studyId) {
         return query
-                .select(new QStudyApplicantInformation(member.id, member.nickname, participant.createdAt))
+                .select(new QStudyApplicantInformation(member.id, member.nickname, member.score, participant.createdAt))
                 .from(participant)
                 .innerJoin(participant.member, member)
                 .where(studyIdEq(studyId), applyStatus())

--- a/src/main/java/com/kgu/studywithme/study/infra/query/dto/response/StudyApplicantInformation.java
+++ b/src/main/java/com/kgu/studywithme/study/infra/query/dto/response/StudyApplicantInformation.java
@@ -1,6 +1,7 @@
 package com.kgu.studywithme.study.infra.query.dto.response;
 
 import com.kgu.studywithme.member.domain.Nickname;
+import com.kgu.studywithme.member.domain.Score;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 
@@ -10,12 +11,14 @@ import java.time.LocalDateTime;
 public class StudyApplicantInformation {
     private final Long id;
     private final String nickname;
+    private final int score;
     private final LocalDateTime applyDate;
 
     @QueryProjection
-    public StudyApplicantInformation(Long id, Nickname nickname, LocalDateTime applyDate) {
+    public StudyApplicantInformation(Long id, Nickname nickname, Score score, LocalDateTime applyDate) {
         this.id = id;
         this.nickname = nickname.getValue();
+        this.score = score.getValue();
         this.applyDate = applyDate;
     }
 }

--- a/src/test/java/com/kgu/studywithme/member/controller/MemberInformationApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/member/controller/MemberInformationApiControllerTest.java
@@ -152,6 +152,7 @@ class MemberInformationApiControllerTest extends ControllerTest {
                                             fieldWithPath("gender").description("사용자 성별"),
                                             fieldWithPath("region.province").description("거주지 [경기도, 강원도, ...]"),
                                             fieldWithPath("region.city").description("거주지 [안양시, 수원시, ...]"),
+                                            fieldWithPath("score").description("사용자 점수"),
                                             fieldWithPath("interests[]").description("사용자 관심사 목록")
                                     )
                             )

--- a/src/test/java/com/kgu/studywithme/member/domain/ScoreTest.java
+++ b/src/test/java/com/kgu/studywithme/member/domain/ScoreTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,9 +34,8 @@ class ScoreTest {
     @DisplayName("Minimum보다 낮은 Score를 설정할 경우 Minimum으로 변경된다")
     void minimum() {
         // given
-        Score score = Score.initScore(); // 100
-        ReflectionTestUtils.setField(score, "value", 0); // 0
-        
+        Score score = Score.from(0); // 100
+
         // when
         Score updateScore = score.applyLate(); // 0 - 1
         
@@ -52,8 +50,7 @@ class ScoreTest {
 
         @BeforeEach
         void setUp() {
-            score = Score.initScore(); // 100
-            ReflectionTestUtils.setField(score, "value", 75); // 75
+            score = Score.from(75); // 75
         }
 
         @Test
@@ -94,8 +91,7 @@ class ScoreTest {
 
         @BeforeEach
         void setUp() {
-            score = Score.initScore(); // 100
-            ReflectionTestUtils.setField(score, "value", 75); // 75
+            score = Score.from(75); // 75
         }
 
         @Test

--- a/src/test/java/com/kgu/studywithme/study/controller/StudyInformationApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/study/controller/StudyInformationApiControllerTest.java
@@ -4,6 +4,7 @@ import com.kgu.studywithme.auth.exception.AuthErrorCode;
 import com.kgu.studywithme.common.ControllerTest;
 import com.kgu.studywithme.member.domain.Member;
 import com.kgu.studywithme.member.domain.Nickname;
+import com.kgu.studywithme.member.domain.Score;
 import com.kgu.studywithme.study.domain.Study;
 import com.kgu.studywithme.study.exception.StudyErrorCode;
 import com.kgu.studywithme.study.infra.query.dto.response.CommentInformation;
@@ -373,11 +374,11 @@ class StudyInformationApiControllerTest extends ControllerTest {
             given(jwtTokenProvider.getId(anyString())).willReturn(HOST_ID);
 
             StudyApplicant response = new StudyApplicant(List.of(
-                    new StudyApplicantInformation(1L, Nickname.from("닉네임1"), LocalDateTime.now().minusDays(1)),
-                    new StudyApplicantInformation(2L, Nickname.from("닉네임2"), LocalDateTime.now().minusDays(2)),
-                    new StudyApplicantInformation(3L, Nickname.from("닉네임3"), LocalDateTime.now().minusDays(3)),
-                    new StudyApplicantInformation(4L, Nickname.from("닉네임4"), LocalDateTime.now().minusDays(4)),
-                    new StudyApplicantInformation(5L, Nickname.from("닉네임5"), LocalDateTime.now().minusDays(5))
+                    new StudyApplicantInformation(1L, Nickname.from("닉네임1"), Score.from(100), LocalDateTime.now().minusDays(1)),
+                    new StudyApplicantInformation(2L, Nickname.from("닉네임2"), Score.from(92), LocalDateTime.now().minusDays(2)),
+                    new StudyApplicantInformation(3L, Nickname.from("닉네임3"), Score.from(93), LocalDateTime.now().minusDays(3)),
+                    new StudyApplicantInformation(4L, Nickname.from("닉네임4"), Score.from(98), LocalDateTime.now().minusDays(4)),
+                    new StudyApplicantInformation(5L, Nickname.from("닉네임5"), Score.from(95), LocalDateTime.now().minusDays(5))
             ));
             given(studyInformationService.getApplicants(STUDY_ID)).willReturn(response);
 
@@ -401,6 +402,7 @@ class StudyInformationApiControllerTest extends ControllerTest {
                                     responseFields(
                                             fieldWithPath("applicants[].id").description("신청자 ID(PK)"),
                                             fieldWithPath("applicants[].nickname").description("신청자 닉네임"),
+                                            fieldWithPath("applicants[].score").description("신청자 점수"),
                                             fieldWithPath("applicants[].applyDate").description("신청 날짜")
                                     )
                             )

--- a/src/test/java/com/kgu/studywithme/study/infra/query/StudyInformationQueryRepositoryTest.java
+++ b/src/test/java/com/kgu/studywithme/study/infra/query/StudyInformationQueryRepositoryTest.java
@@ -390,7 +390,8 @@ class StudyInformationQueryRepositoryTest extends RepositoryTest {
 
             assertAll(
                     () -> assertThat(information.getId()).isEqualTo(member.getId()),
-                    () -> assertThat(information.getNickname()).isEqualTo(member.getNicknameValue())
+                    () -> assertThat(information.getNickname()).isEqualTo(member.getNicknameValue()),
+                    () -> assertThat(information.getScore()).isEqualTo(member.getScore())
             );
         }
     }

--- a/src/test/java/com/kgu/studywithme/study/service/StudyInformationServiceTest.java
+++ b/src/test/java/com/kgu/studywithme/study/service/StudyInformationServiceTest.java
@@ -476,7 +476,8 @@ class StudyInformationServiceTest extends ServiceTest {
 
             assertAll(
                     () -> assertThat(information.getId()).isEqualTo(member.getId()),
-                    () -> assertThat(information.getNickname()).isEqualTo(member.getNicknameValue())
+                    () -> assertThat(information.getNickname()).isEqualTo(member.getNicknameValue()),
+                    () -> assertThat(information.getScore()).isEqualTo(member.getScore())
             );
         }
     }


### PR DESCRIPTION
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [X] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 정상적으로 프로그램이 동작하나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 결석자에 대한 Score 업데이트 누락 추가
- 사용자 점수가 필요한 응답 스펙에 점수 추가
- 테스트 코드 수정 및 보완

Closes #170
