### PR TITLE
[fix] API를 요청한 사용자가 스터디 참여자인지 판별하는 AOP 로직에 대한 버그를 수정한다

### DIFF
--- a/src/main/java/com/kgu/studywithme/global/annotation/aop/CheckStudyParticipantAspect.java
+++ b/src/main/java/com/kgu/studywithme/global/annotation/aop/CheckStudyParticipantAspect.java
@@ -1,9 +1,6 @@
 package com.kgu.studywithme.global.annotation.aop;
 
-import com.kgu.studywithme.member.domain.Member;
-import com.kgu.studywithme.member.service.MemberFindService;
-import com.kgu.studywithme.study.domain.Study;
-import com.kgu.studywithme.study.service.StudyFindService;
+import com.kgu.studywithme.study.service.StudyValidator;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
@@ -13,14 +10,10 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class CheckStudyParticipantAspect {
-    private final StudyFindService studyFindService;
-    private final MemberFindService memberFindService;
+    private final StudyValidator studyValidator;
 
     @Before("@annotation(com.kgu.studywithme.global.annotation.aop.CheckStudyParticipant) && args(memberId, studyId, ..)")
     public void checkParticipant(Long studyId, Long memberId) {
-        Study study = studyFindService.findById(studyId);
-        Member member = memberFindService.findById(memberId);
-
-        study.validateMemberIsParticipant(member);
+        studyValidator.validateStudyParticipant(studyId, memberId);
     }
 }

--- a/src/main/java/com/kgu/studywithme/global/exception/ApiGlobalExceptionHandler.java
+++ b/src/main/java/com/kgu/studywithme/global/exception/ApiGlobalExceptionHandler.java
@@ -197,7 +197,7 @@ public class ApiGlobalExceptionHandler {
                         List.of(
                                 generateSlackField(TITLE_REQUEST_IP, (xffHeader == null) ? request.getRemoteAddr() : xffHeader),
                                 generateSlackField(TITLE_REQUEST_URL, request.getMethod() + " " + request.getRequestURL()),
-                                generateSlackField(TITLE_ERROR_MESSAGE, e.getMessage())
+                                generateSlackField(TITLE_ERROR_MESSAGE, e.toString())
                         )
                 )
                 .build();

--- a/src/main/java/com/kgu/studywithme/study/infra/query/StudySimpleQueryRepository.java
+++ b/src/main/java/com/kgu/studywithme/study/infra/query/StudySimpleQueryRepository.java
@@ -13,4 +13,5 @@ public interface StudySimpleQueryRepository {
     List<SimpleStudy> findGraduatedStudyByMemberId(Long memberId);
     List<BasicWeekly> findAutoAttendanceAndPeriodEndWeek();
     List<BasicAttendance> findBasicAttendanceInformation();
+    boolean isStudyParticipant(Long studyId, Long memberId);
 }

--- a/src/main/java/com/kgu/studywithme/study/service/StudyValidator.java
+++ b/src/main/java/com/kgu/studywithme/study/service/StudyValidator.java
@@ -39,6 +39,12 @@ public class StudyValidator {
         }
     }
 
+    public void validateStudyParticipant(Long studyId, Long memberId) {
+        if (!studyRepository.isStudyParticipant(studyId, memberId)) {
+            throw StudyWithMeException.type(StudyErrorCode.MEMBER_IS_NOT_PARTICIPANT);
+        }
+    }
+
     public void validateNoticeWriter(Long noticeId, Long memberId) {
         if (!noticeRepository.existsByIdAndWriterId(noticeId, memberId)) {
             throw StudyWithMeException.type(MemberErrorCode.MEMBER_IS_NOT_WRITER);

--- a/src/test/java/com/kgu/studywithme/common/config/TestAopConfiguration.java
+++ b/src/test/java/com/kgu/studywithme/common/config/TestAopConfiguration.java
@@ -3,8 +3,6 @@ package com.kgu.studywithme.common.config;
 import com.kgu.studywithme.global.annotation.aop.CheckMemberIdentityAspect;
 import com.kgu.studywithme.global.annotation.aop.CheckStudyHostAspect;
 import com.kgu.studywithme.global.annotation.aop.CheckStudyParticipantAspect;
-import com.kgu.studywithme.member.service.MemberFindService;
-import com.kgu.studywithme.study.service.StudyFindService;
 import com.kgu.studywithme.study.service.StudyValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -16,8 +14,6 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 @EnableAspectJAutoProxy
 public class TestAopConfiguration {
     private final StudyValidator studyValidator;
-    private final StudyFindService studyFindService;
-    private final MemberFindService memberFindService;
 
     @Bean
     public CheckMemberIdentityAspect checkMemberIdentityAspect() {
@@ -26,7 +22,7 @@ public class TestAopConfiguration {
 
     @Bean
     public CheckStudyParticipantAspect checkStudyParticipantAspect() {
-        return new CheckStudyParticipantAspect(studyFindService, memberFindService);
+        return new CheckStudyParticipantAspect(studyValidator);
     }
 
     @Bean

--- a/src/test/java/com/kgu/studywithme/study/controller/StudyInformationApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/study/controller/StudyInformationApiControllerTest.java
@@ -28,7 +28,8 @@ import java.util.Map;
 
 import static com.kgu.studywithme.common.utils.TokenUtils.ACCESS_TOKEN;
 import static com.kgu.studywithme.common.utils.TokenUtils.BEARER_TOKEN;
-import static com.kgu.studywithme.fixture.MemberFixture.*;
+import static com.kgu.studywithme.fixture.MemberFixture.GHOST;
+import static com.kgu.studywithme.fixture.MemberFixture.JIWON;
 import static com.kgu.studywithme.fixture.StudyFixture.TOSS_INTERVIEW;
 import static com.kgu.studywithme.fixture.WeekFixture.*;
 import static com.kgu.studywithme.study.domain.attendance.AttendanceStatus.*;
@@ -162,8 +163,8 @@ class StudyInformationApiControllerTest extends ControllerTest {
 
         @BeforeEach
         void setUp() {
-            Study study = createSpringStudy(HOST_ID, STUDY_ID);
-            mockingForStudyParticipant(study, DUMMY1, ANONYMOUS_ID, false);
+            mockingForStudyParticipant(STUDY_ID, HOST_ID, true);
+            mockingForStudyParticipant(STUDY_ID, ANONYMOUS_ID, false);
         }
 
         @Test
@@ -420,8 +421,8 @@ class StudyInformationApiControllerTest extends ControllerTest {
 
         @BeforeEach
         void setUp() {
-            Study study = createSpringStudy(HOST_ID, STUDY_ID);
-            mockingForStudyParticipant(study, DUMMY1, ANONYMOUS_ID, false);
+            mockingForStudyParticipant(STUDY_ID, HOST_ID, true);
+            mockingForStudyParticipant(STUDY_ID, ANONYMOUS_ID, false);
         }
 
         @Test
@@ -542,8 +543,8 @@ class StudyInformationApiControllerTest extends ControllerTest {
 
         @BeforeEach
         void setUp() {
-            Study study = createSpringStudy(HOST_ID, STUDY_ID);
-            mockingForStudyParticipant(study, DUMMY1, ANONYMOUS_ID, false);
+            mockingForStudyParticipant(STUDY_ID, HOST_ID, true);
+            mockingForStudyParticipant(STUDY_ID, ANONYMOUS_ID, false);
         }
 
         @Test

--- a/src/test/java/com/kgu/studywithme/study/controller/StudyParticipationApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/study/controller/StudyParticipationApiControllerTest.java
@@ -5,7 +5,6 @@ import com.kgu.studywithme.common.ControllerTest;
 import com.kgu.studywithme.global.exception.GlobalErrorCode;
 import com.kgu.studywithme.global.exception.StudyWithMeException;
 import com.kgu.studywithme.study.controller.dto.request.ParticipationRejectRequest;
-import com.kgu.studywithme.study.domain.Study;
 import com.kgu.studywithme.study.exception.StudyErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,8 +15,6 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 
 import static com.kgu.studywithme.common.utils.TokenUtils.ACCESS_TOKEN;
 import static com.kgu.studywithme.common.utils.TokenUtils.BEARER_TOKEN;
-import static com.kgu.studywithme.fixture.MemberFixture.DUMMY1;
-import static com.kgu.studywithme.fixture.MemberFixture.DUMMY2;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -922,9 +919,9 @@ class StudyParticipationApiControllerTest extends ControllerTest {
 
         @BeforeEach
         void setUp() {
-            Study study = createSpringStudy(HOST_ID, STUDY_ID);
-            mockingForStudyParticipant(study, DUMMY1, PARTICIPANT_ID, true);
-            mockingForStudyParticipant(study, DUMMY2, ANONYMOUS_ID, false);
+            mockingForStudyParticipant(STUDY_ID, HOST_ID, true);
+            mockingForStudyParticipant(STUDY_ID, PARTICIPANT_ID, true);
+            mockingForStudyParticipant(STUDY_ID, ANONYMOUS_ID, false);
         }
 
         @Test
@@ -1326,9 +1323,9 @@ class StudyParticipationApiControllerTest extends ControllerTest {
 
         @BeforeEach
         void setUp() {
-            Study study = createSpringStudy(HOST_ID, STUDY_ID);
-            mockingForStudyParticipant(study, DUMMY1, PARTICIPANT_ID, true);
-            mockingForStudyParticipant(study, DUMMY2, ANONYMOUS_ID, false);
+            mockingForStudyParticipant(STUDY_ID, HOST_ID, true);
+            mockingForStudyParticipant(STUDY_ID, PARTICIPANT_ID, true);
+            mockingForStudyParticipant(STUDY_ID, ANONYMOUS_ID, false);
         }
 
         @Test

--- a/src/test/java/com/kgu/studywithme/study/controller/week/StudyWeeklyApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/study/controller/week/StudyWeeklyApiControllerTest.java
@@ -4,7 +4,6 @@ import com.kgu.studywithme.auth.exception.AuthErrorCode;
 import com.kgu.studywithme.common.ControllerTest;
 import com.kgu.studywithme.global.exception.StudyWithMeException;
 import com.kgu.studywithme.study.controller.dto.request.StudyWeeklyRequest;
-import com.kgu.studywithme.study.domain.Study;
 import com.kgu.studywithme.study.exception.StudyErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,7 +22,6 @@ import static com.kgu.studywithme.common.utils.FileMockingUtils.createMultipleMo
 import static com.kgu.studywithme.common.utils.FileMockingUtils.createSingleMockMultipartFile;
 import static com.kgu.studywithme.common.utils.TokenUtils.ACCESS_TOKEN;
 import static com.kgu.studywithme.common.utils.TokenUtils.BEARER_TOKEN;
-import static com.kgu.studywithme.fixture.MemberFixture.DUMMY1;
 import static com.kgu.studywithme.fixture.WeekFixture.STUDY_WEEKLY_1;
 import static com.kgu.studywithme.study.controller.utils.StudyWeeklyRequestUtils.createWeekWithAssignmentRequest;
 import static org.mockito.ArgumentMatchers.any;
@@ -252,8 +250,8 @@ class StudyWeeklyApiControllerTest extends ControllerTest {
 
         @BeforeEach
         void setUp() throws IOException {
-            Study study = createSpringStudy(HOST_ID, STUDY_ID);
-            mockingForStudyParticipant(study, DUMMY1, ANONYMOUS_ID, false);
+            mockingForStudyParticipant(STUDY_ID, HOST_ID, true);
+            mockingForStudyParticipant(STUDY_ID, ANONYMOUS_ID, false);
 
             file = createSingleMockMultipartFile("hello3.pdf", "application/pdf");
         }
@@ -557,8 +555,8 @@ class StudyWeeklyApiControllerTest extends ControllerTest {
 
         @BeforeEach
         void setUp() throws IOException {
-            Study study = createSpringStudy(HOST_ID, STUDY_ID);
-            mockingForStudyParticipant(study, DUMMY1, ANONYMOUS_ID, false);
+            mockingForStudyParticipant(STUDY_ID, HOST_ID, true);
+            mockingForStudyParticipant(STUDY_ID, ANONYMOUS_ID, false);
 
             file = createSingleMockMultipartFile("hello3.pdf", "application/pdf");
         }

--- a/src/test/java/com/kgu/studywithme/study/infra/query/StudySimpleQueryRepositoryTest.java
+++ b/src/test/java/com/kgu/studywithme/study/infra/query/StudySimpleQueryRepositoryTest.java
@@ -259,6 +259,37 @@ class StudySimpleQueryRepositoryTest extends RepositoryTest {
         assertThat(attendances).hasSize(28);
     }
 
+    @Test
+    @DisplayName("스터디 참여자인지 확인한다")
+    void isStudyParticipant() {
+        // 1. 미참여
+        assertAll(
+                () -> assertThat(studyRepository.isStudyParticipant(programming[0].getId(), host.getId())).isTrue(),
+                () -> assertThat(studyRepository.isStudyParticipant(programming[0].getId(), member.getId())).isFalse()
+        );
+
+        // 2. 참여 신청
+        applyStudy(member, programming[0]);
+        assertAll(
+                () -> assertThat(studyRepository.isStudyParticipant(programming[0].getId(), host.getId())).isTrue(),
+                () -> assertThat(studyRepository.isStudyParticipant(programming[0].getId(), member.getId())).isFalse()
+        );
+
+        // 3. 참여 승인
+        participateStudy(member, programming[0]);
+        assertAll(
+                () -> assertThat(studyRepository.isStudyParticipant(programming[0].getId(), host.getId())).isTrue(),
+                () -> assertThat(studyRepository.isStudyParticipant(programming[0].getId(), member.getId())).isTrue()
+        );
+
+        // 4. 졸업
+        graduateStudy(member, programming[0]);
+        assertAll(
+                () -> assertThat(studyRepository.isStudyParticipant(programming[0].getId(), host.getId())).isTrue(),
+                () -> assertThat(studyRepository.isStudyParticipant(programming[0].getId(), member.getId())).isFalse()
+        );
+    }
+
     private void applyStudy(Member member, Study... studies) {
         for (Study study : studies) {
             study.applyParticipation(member);
@@ -275,6 +306,10 @@ class StudySimpleQueryRepositoryTest extends RepositoryTest {
         for (Study study : studies) {
             study.rejectParticipation(member);
         }
+    }
+
+    private void graduateStudy(Member member, Study study) {
+        study.graduateParticipant(member);
     }
 
     private void applyAndParticipateStudy(Member member, Study... studies) {

--- a/src/test/java/com/kgu/studywithme/study/service/StudyValidatorTest.java
+++ b/src/test/java/com/kgu/studywithme/study/service/StudyValidatorTest.java
@@ -74,6 +74,15 @@ class StudyValidatorTest extends ServiceTest {
                 .hasMessage(StudyErrorCode.MEMBER_IS_NOT_HOST.getMessage());
         assertDoesNotThrow(() -> studyValidator.validateHost(study.getId(), host.getId()));
     }
+
+    @Test
+    @DisplayName("스터디 참여자에 대한 검증을 진행한다")
+    void validateStudyParticipant() {
+        assertThatThrownBy(() -> studyValidator.validateStudyParticipant(study.getId(), host.getId() + 100L))
+                .isInstanceOf(StudyWithMeException.class)
+                .hasMessage(StudyErrorCode.MEMBER_IS_NOT_PARTICIPANT.getMessage());
+        assertDoesNotThrow(() -> studyValidator.validateStudyParticipant(study.getId(), host.getId()));
+    }
     
     @Test
     @DisplayName("스터디 공지사항 작성자에 대한 검증을 진행한다")


### PR DESCRIPTION
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [X] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 정상적으로 프로그램이 동작하나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- `@CheckStudyParticipant` AOP 로직에 대한 JPA 영속성 컨텍스트 `LazyInitializationException` 오류 해결


Closes #177