### PR TITLE
[refactor] 사용자 기본 정보에 이메일 수신 동의 필드를 추가한다

### DIFF
--- a/src/main/java/com/kgu/studywithme/member/service/dto/response/MemberInformation.java
+++ b/src/main/java/com/kgu/studywithme/member/service/dto/response/MemberInformation.java
@@ -8,8 +8,8 @@ import java.time.LocalDate;
 import java.util.List;
 
 public record MemberInformation(
-        Long id, String name, String nickname, String email, LocalDate birth,
-        String phone, String gender, Region region, int score, List<String> interests
+        Long id, String name, String nickname, String email, LocalDate birth, String phone,
+        String gender, Region region, int score, boolean isEmailOptIn, List<String> interests
 ) {
     public MemberInformation(Member member) {
         this(
@@ -22,6 +22,7 @@ public record MemberInformation(
                 member.getGender().getValue(),
                 member.getRegion(),
                 member.getScore(),
+                member.isEmailOptIn(),
                 translateInterests(member)
         );
     }

--- a/src/test/java/com/kgu/studywithme/member/controller/MemberInformationApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/member/controller/MemberInformationApiControllerTest.java
@@ -83,6 +83,7 @@ class MemberInformationApiControllerTest extends ControllerTest {
                                             fieldWithPath("region.province").description("거주지 [경기도, 강원도, ...]"),
                                             fieldWithPath("region.city").description("거주지 [안양시, 수원시, ...]"),
                                             fieldWithPath("score").description("사용자 점수"),
+                                            fieldWithPath("isEmailOptIn").description("이메일 수신 동의 여부"),
                                             fieldWithPath("interests[]").description("사용자 관심사 목록")
                                     )
                             )

--- a/src/test/java/com/kgu/studywithme/member/service/MemberInformationServiceTest.java
+++ b/src/test/java/com/kgu/studywithme/member/service/MemberInformationServiceTest.java
@@ -66,6 +66,7 @@ class MemberInformationServiceTest extends ServiceTest {
                 () -> assertThat(information.gender()).isEqualTo(member.getGender().getValue()),
                 () -> assertThat(information.region()).isEqualTo(member.getRegion()),
                 () -> assertThat(information.score()).isEqualTo(member.getScore()),
+                () -> assertThat(information.isEmailOptIn()).isEqualTo(member.isEmailOptIn()),
                 () -> assertThat(information.interests()).containsExactlyInAnyOrder(
                         LANGUAGE.getName(), INTERVIEW.getName(), PROGRAMMING.getName()
                 )
@@ -166,8 +167,8 @@ class MemberInformationServiceTest extends ServiceTest {
         programming[0].recordAttendance(host, 1, NON_ATTENDANCE);
         programming[1].recordAttendance(host, 1, ATTENDANCE);
         List<AttendanceRatio> result1 = memberInformationService.getAttendanceRatio(host.getId()).result();
+        assertThat(result1).hasSize(4);
         assertAll(
-                () -> assertThat(result1).hasSize(4),
                 () -> assertThat(findCountByStatus(result1, NON_ATTENDANCE)).isEqualTo(1),
                 () -> assertThat(findCountByStatus(result1, ATTENDANCE)).isEqualTo(1),
                 () -> assertThat(findCountByStatus(result1, LATE)).isEqualTo(0),
@@ -178,8 +179,8 @@ class MemberInformationServiceTest extends ServiceTest {
         programming[0].recordAttendance(host, 2, ATTENDANCE);
         programming[1].recordAttendance(host, 2, LATE);
         List<AttendanceRatio> result2 = memberInformationService.getAttendanceRatio(host.getId()).result();
+        assertThat(result2).hasSize(4);
         assertAll(
-                () -> assertThat(result2).hasSize(4),
                 () -> assertThat(findCountByStatus(result2, NON_ATTENDANCE)).isEqualTo(1),
                 () -> assertThat(findCountByStatus(result2, ATTENDANCE)).isEqualTo(2),
                 () -> assertThat(findCountByStatus(result2, LATE)).isEqualTo(1),
@@ -190,8 +191,8 @@ class MemberInformationServiceTest extends ServiceTest {
         programming[0].recordAttendance(host, 3, ATTENDANCE);
         programming[1].recordAttendance(host, 3, ATTENDANCE);
         List<AttendanceRatio> result3 = memberInformationService.getAttendanceRatio(host.getId()).result();
+        assertThat(result3).hasSize(4);
         assertAll(
-                () -> assertThat(result3).hasSize(4),
                 () -> assertThat(findCountByStatus(result3, NON_ATTENDANCE)).isEqualTo(1),
                 () -> assertThat(findCountByStatus(result3, ATTENDANCE)).isEqualTo(4),
                 () -> assertThat(findCountByStatus(result3, LATE)).isEqualTo(1),
@@ -202,8 +203,8 @@ class MemberInformationServiceTest extends ServiceTest {
         programming[0].recordAttendance(host, 4, LATE);
         programming[1].recordAttendance(host, 4, ABSENCE);
         List<AttendanceRatio> result4 = memberInformationService.getAttendanceRatio(host.getId()).result();
+        assertThat(result4).hasSize(4);
         assertAll(
-                () -> assertThat(result4).hasSize(4),
                 () -> assertThat(findCountByStatus(result4, NON_ATTENDANCE)).isEqualTo(1),
                 () -> assertThat(findCountByStatus(result4, ATTENDANCE)).isEqualTo(4),
                 () -> assertThat(findCountByStatus(result4, LATE)).isEqualTo(2),
@@ -214,8 +215,8 @@ class MemberInformationServiceTest extends ServiceTest {
         programming[0].recordAttendance(host, 5, ABSENCE);
         programming[1].recordAttendance(host, 5, NON_ATTENDANCE);
         List<AttendanceRatio> result5 = memberInformationService.getAttendanceRatio(host.getId()).result();
+        assertThat(result5).hasSize(4);
         assertAll(
-                () -> assertThat(result5).hasSize(4),
                 () -> assertThat(findCountByStatus(result5, NON_ATTENDANCE)).isEqualTo(2),
                 () -> assertThat(findCountByStatus(result5, ATTENDANCE)).isEqualTo(4),
                 () -> assertThat(findCountByStatus(result5, LATE)).isEqualTo(2),


### PR DESCRIPTION
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [X] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 정상적으로 프로그램이 동작하나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 사용자에 대한 기본 정보 조회 API 응답에 이메일 수신 동의 필드 추가

Closes #203
