### PR TITLE
[fix] 주차 삭제 시 해당 주차와 관련된 출석 정보가 삭제되지 않는 오류를 수정한다

### DIFF
--- a/src/main/java/com/kgu/studywithme/study/infra/query/StudySimpleQueryRepositoryImpl.java
+++ b/src/main/java/com/kgu/studywithme/study/infra/query/StudySimpleQueryRepositoryImpl.java
@@ -137,11 +137,7 @@ public class StudySimpleQueryRepositoryImpl implements StudySimpleQueryRepositor
                 .orderBy(weekly.week.desc())
                 .fetch();
 
-        if (weeks.size() == 0) {
-            return 1;
-        }
-
-        return weeks.get(0) + 1;
+        return weeks.size() == 0 ? 1 : weeks.get(0) + 1;
     }
 
     @Override
@@ -176,17 +172,26 @@ public class StudySimpleQueryRepositoryImpl implements StudySimpleQueryRepositor
                 )
                 .fetchOne();
 
-        query.delete(submit)
-                .where(submit.week.id.eq(weekId))
-                .execute();
+        if (weekId != null) {
+            query.delete(submit)
+                    .where(submit.week.id.eq(weekId))
+                    .execute();
 
-        query.delete(attachment)
-                .where(attachment.week.id.eq(weekId))
-                .execute();
+            query.delete(attachment)
+                    .where(attachment.week.id.eq(weekId))
+                    .execute();
 
-        query.delete(weekly)
-                .where(weekly.id.eq(weekId))
-                .execute();
+            query.delete(attendance)
+                    .where(
+                            attendance.study.id.eq(studyId),
+                            attendance.week.eq(week)
+                    )
+                    .execute();
+
+            query.delete(weekly)
+                    .where(weekly.id.eq(weekId))
+                    .execute();
+        }
     }
 
     private BooleanExpression participateStatusEq(ParticipantStatus status) {

--- a/src/test/java/com/kgu/studywithme/study/infra/query/StudySimpleQueryRepositoryTest.java
+++ b/src/test/java/com/kgu/studywithme/study/infra/query/StudySimpleQueryRepositoryTest.java
@@ -307,12 +307,20 @@ class StudySimpleQueryRepositoryTest extends RepositoryTest {
         // given
         Study study = studyRepository.save(GOOGLE_INTERVIEW.toOfflineStudy(host));
         
-        /* 1주차 */
+        /* next = 1주차 */
         assertThat(studyRepository.getNextWeek(study.getId())).isEqualTo(1);
         
-        /* 2주차 */
+        /* next = 2주차 */
         weekRepository.save(STUDY_WEEKLY_1.toWeekWithAssignment(study));
         assertThat(studyRepository.getNextWeek(study.getId())).isEqualTo(2);
+
+        /* next = 3주차 */
+        weekRepository.save(STUDY_WEEKLY_2.toWeekWithAssignment(study));
+        assertThat(studyRepository.getNextWeek(study.getId())).isEqualTo(3);
+
+        /* next = 4주차 */
+        weekRepository.save(STUDY_WEEKLY_3.toWeekWithAssignment(study));
+        assertThat(studyRepository.getNextWeek(study.getId())).isEqualTo(4);
     }
 
     @Test


### PR DESCRIPTION
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [X] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 정상적으로 프로그램이 동작하나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 주차 삭제 시 해당 주차와 관련된 출석 정보 삭제 로직 추가

Closes #215